### PR TITLE
Add support for the MySQL JSON data type

### DIFF
--- a/include/protocol.hrl
+++ b/include/protocol.hrl
@@ -113,6 +113,7 @@
 -define(TYPE_YEAR, 16#0d).
 -define(TYPE_VARCHAR, 16#0f).
 -define(TYPE_BIT, 16#10).
+-define(TYPE_JSON, 16#f5).
 -define(TYPE_NEWDECIMAL, 16#f6).
 -define(TYPE_ENUM, 16#f7).
 -define(TYPE_SET, 16#f8).

--- a/src/mysql_protocol.erl
+++ b/src/mysql_protocol.erl
@@ -459,7 +459,7 @@ decode_text(#col{type = T}, Text)
   when T == ?TYPE_STRING; T == ?TYPE_VARCHAR; T == ?TYPE_VAR_STRING;
        T == ?TYPE_ENUM; T == ?TYPE_SET; T == ?TYPE_LONG_BLOB;
        T == ?TYPE_MEDIUM_BLOB; T == ?TYPE_BLOB; T == ?TYPE_TINY_BLOB;
-       T == ?TYPE_GEOMETRY ->
+       T == ?TYPE_GEOMETRY; T == ?TYPE_JSON ->
     %% As of MySQL 5.6.21 we receive SET and ENUM values as STRING, i.e. we
     %% cannot convert them to atom() or sets:set(), etc.
     Text;
@@ -607,7 +607,7 @@ decode_binary(#col{type = T}, Data)
   when T == ?TYPE_STRING; T == ?TYPE_VARCHAR; T == ?TYPE_VAR_STRING;
        T == ?TYPE_ENUM; T == ?TYPE_SET; T == ?TYPE_LONG_BLOB;
        T == ?TYPE_MEDIUM_BLOB; T == ?TYPE_BLOB; T == ?TYPE_TINY_BLOB;
-       T == ?TYPE_GEOMETRY ->
+       T == ?TYPE_GEOMETRY; T == ?TYPE_JSON ->
     %% As of MySQL 5.6.21 we receive SET and ENUM values as STRING, i.e. we
     %% cannot convert them to atom() or sets:set(), etc.
     lenenc_str(Data);


### PR DESCRIPTION
This commit adds support for the JSON data type introduced
in MySQL 5.7.8.

The unit test for JSON is very fragile as it compares strings
directly. It should use a proper JSON parser and compare the
parsed terms.