### PR TITLE
Allow setting CLIENT_FOUND_ROWS on handshake.

### DIFF
--- a/include/protocol.hrl
+++ b/include/protocol.hrl
@@ -26,6 +26,9 @@
 
 %% --- Capability flags ---
 
+%% Server: sends found rows instead of affected rows in EOF_Packet
+-define(CLIENT_FOUND_ROWS, 16#00000002).
+
 %% Server: supports schema-name in Handshake Response Packet
 %% Client: Handshake Response Packet contains a schema-name
 -define(CLIENT_CONNECT_WITH_DB, 16#00000008).
@@ -124,5 +127,3 @@
 -define(TYPE_VAR_STRING, 16#fd).
 -define(TYPE_STRING, 16#fe).
 -define(TYPE_GEOMETRY, 16#ff).
-
-

--- a/test/mysql_protocol_tests.erl
+++ b/test/mysql_protocol_tests.erl
@@ -110,11 +110,11 @@ prepare_test() ->
                            warning_count = 0} when is_integer(StmtId),
                  Result),
     ok.
-    
+
 bad_protocol_version_test() ->
     Sock = mock_tcp:create([{recv, <<2, 0, 0, 0, 9, 0>>}]),
     ?assertError(unknown_protocol,
-                 mysql_protocol:handshake("foo", "bar", "db", mock_tcp, Sock)),
+                 mysql_protocol:handshake("foo", "bar", "db", mock_tcp, Sock, false)),
     mock_tcp:close(Sock).
 
 %% --- Helper functions for the above tests ---


### PR DESCRIPTION
The option is useful for compatibility with other SQL databases and
drivers (ODBC, PostgreSQL).