### PR TITLE
fix mysql connect timeout.

### DIFF
--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -489,7 +489,7 @@ init(Opts) ->
     end,
 
     %% Connect socket
-    SockOpts = [binary, {packet, raw} | TcpOpts],
+    SockOpts = [binary, {packet, raw},{active, false} | TcpOpts],
     {ok, Socket} = gen_tcp:connect(Host, Port, SockOpts),
 
     %% Exchange handshake communication.


### PR DESCRIPTION
mysql 5.7.17
when mysql client connect to mysql server success, mysql server will push handshake data immediately.
fix sometimes mysql_otp client may lost receive handshake data.