### PR TITLE
Add support for auth method switch

### DIFF
--- a/include/records.hrl
+++ b/include/records.hrl
@@ -27,6 +27,11 @@
                     auth_plugin_data :: binary(),
                     auth_plugin_name :: binary()}).
 
+-record(auth_method_switch, {
+          auth_plugin_name :: binary(),
+          auth_plugin_data :: binary()
+         }).
+
 %% OK packet, commonly used in the protocol.
 -record(ok, {affected_rows :: integer(),
              insert_id :: integer(),


### PR DESCRIPTION
This PR adds support for `AuthSwitchRequest` packet that can be returned by the server as a result to handshake response. This is required e.g. to connect to managed MySQL instance in Microsoft Azure, which doesn't allow "fast authentication path".

Most probably this improvement doesn't cover all possible paths but is sufficient to connect to Azure's MySQL.