### PR TITLE
Dont use throw for implicit_rollback, use error as with implicit_commit.

### DIFF
--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -394,12 +394,12 @@ execute_transaction(Conn, Fun, Args, Retries) ->
     catch
         %% We are at the top level, try to restart the transaction if there are
         %% retries left
-        ?EXCEPTION(throw, {implicit_rollback, 1, _}, _Stacktrace) when Retries =:= infinity ->
+        ?EXCEPTION(error, {implicit_rollback, 1, _}, _Stacktrace) when Retries =:= infinity ->
             execute_transaction(Conn, Fun, Args, infinity);
-        ?EXCEPTION(throw, {implicit_rollback, 1, _}, _Stacktrace) when Retries > 0 ->
+        ?EXCEPTION(error, {implicit_rollback, 1, _}, _Stacktrace) when Retries > 0 ->
             execute_transaction(Conn, Fun, Args, Retries - 1);
-        ?EXCEPTION(throw, {implicit_rollback, N, Reason}, Stacktrace, N) ->
-            erlang:raise(throw, {implicit_rollback, N - 1, Reason},
+        ?EXCEPTION(error, {implicit_rollback, N, Reason}, Stacktrace, N) ->
+            erlang:raise(error, {implicit_rollback, N - 1, Reason},
                          ?GET_STACK(Stacktrace));
         ?EXCEPTION(error, {implicit_commit, _Query} = E, Stacktrace) ->
             %% The called did something like ALTER TABLE which resulted in an
@@ -795,7 +795,7 @@ query_call(Conn, CallReq) ->
         {implicit_commit, _NestingLevel, Query} ->
             error({implicit_commit, Query});
         {implicit_rollback, _NestingLevel, _ServerReason} = ImplicitRollback ->
-            throw(ImplicitRollback);
+            error(ImplicitRollback);
         Result ->
             Result
     end.


### PR DESCRIPTION
I would understand if this is not accepted but we need it and I could not find a good argument why throw was used.

Anyways, our problems was a try-catch that caught the implicit_rollback.

We have application code that uses throw to signal a broad range of common errors and the like. At one place we had been sloppy and caught too much, the implicit_rollback.

But as I said above, I could not find a good argument for why throw is used since this just limits the functionality of the driver when it does not have to. With this MR it is perfectly fine to catch throw:Value in the transaction function.