### PR TITLE
fix spec for host option in start_link

### DIFF
--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -129,7 +129,8 @@
 %% </dl>
 -spec start_link(Options) -> {ok, pid()} | ignore | {error, term()}
     when Options :: [Option],
-         Option :: {name, ServerName} | {host, iodata()} | {port, integer()} |
+         Option :: {name, ServerName} |
+                   {host, inet:socket_address() | inet:hostname()} | {port, integer()} |
                    {user, iodata()} | {password, iodata()} |
                    {database, iodata()} |
                    {connect_timeout, timeout()} |


### PR DESCRIPTION
The `host` option was specced as `iodata()`, which is defined as `iolist() | binary()`. However, `gen_tcp:connect/{3,4}`, which this parameter is passed down to, wants `socket_address() | hostname()`, which boils down to atoms, strings and IP adress tuples.