### PR TITLE
Clarification for usage with MySQL 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ before_script:
   - cat test/ssl/my-ssl.cnf | sudo tee -a /etc/mysql/conf.d/my-ssl.cnf
   - sudo service mysql start
   - sleep 5
-  - mysql -uroot -e "grant all privileges on otptest.* to otptest@localhost identified by 'otptest'"
-  - mysql -uroot -e "grant all privileges on otptestssl.* to otptestssl@localhost identified by 'otptestssl' require ssl"
+  - mysql -uroot -e "CREATE USER otptest@localhost IDENTIFIED WITH 'mysql_native_password' BY 'otptest';"
+  - mysql -uroot -e "GRANT ALL PRIVILEGES ON otptest.* TO otptest@localhost;"
+  - mysql -uroot -e "CREATE USER otptestssl@localhost IDENTIFIED WITH 'mysql_native_password' BY 'otptestssl' REQUIRE SSL;"
+  - mysql -uroot -e "GRANT ALL PRIVILEGES ON otptest.* TO otptestssl@localhost;"
 script: 'make tests'
 otp_release:
   - 21.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ before_script:
   - cat test/ssl/my-ssl.cnf | sudo tee -a /etc/mysql/conf.d/my-ssl.cnf
   - sudo service mysql start
   - sleep 5
-  - mysql -uroot -e "CREATE USER otptest@localhost IDENTIFIED WITH 'mysql_native_password' BY 'otptest';"
+  - mysql -uroot -e "CREATE USER otptest@localhost IDENTIFIED BY 'otptest';"
   - mysql -uroot -e "GRANT ALL PRIVILEGES ON otptest.* TO otptest@localhost;"
-  - mysql -uroot -e "CREATE USER otptestssl@localhost IDENTIFIED WITH 'mysql_native_password' BY 'otptestssl' REQUIRE SSL;"
+  - mysql -uroot -e "CREATE USER otptestssl@localhost IDENTIFIED BY 'otptestssl' REQUIRE SSL;"
   - mysql -uroot -e "GRANT ALL PRIVILEGES ON otptest.* TO otptestssl@localhost;"
 script: 'make tests'
 otp_release:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_script:
   - sleep 5
   - mysql -uroot -e "CREATE USER otptest@localhost IDENTIFIED BY 'otptest';"
   - mysql -uroot -e "GRANT ALL PRIVILEGES ON otptest.* TO otptest@localhost;"
-  - mysql -uroot -e "CREATE USER otptestssl@localhost IDENTIFIED BY 'otptestssl' REQUIRE SSL;"
-  - mysql -uroot -e "GRANT ALL PRIVILEGES ON otptest.* TO otptestssl@localhost;"
+  - mysql -uroot -e "CREATE USER otptestssl@localhost IDENTIFIED BY 'otptestssl';"
+  - mysql -uroot -e "GRANT ALL PRIVILEGES ON otptest.* TO otptestssl@localhost REQUIRE SSL;"
 script: 'make tests'
 otp_release:
   - 21.1

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ start MySQL on localhost and give privileges to the user `otptest` and (for
 CREATE USER otptest@localhost IDENTIFIED BY 'otptest';
 GRANT ALL PRIVILEGES ON otptest.* TO otptest@localhost;
 
-CREATE USER otptestssl@localhost IDENTIFIED BY 'otptestssl' REQUIRE SSL;
-GRANT ALL PRIVILEGES ON otptest.* TO otptestssl@localhost;
+CREATE USER otptestssl@localhost IDENTIFIED BY 'otptestssl';
+GRANT ALL PRIVILEGES ON otptest.* TO otptestssl@localhost REQUIRE SSL;
 ```
 
 Before running the test suite `ssl_tests` you'll also need to generate SSL files

--- a/README.md
+++ b/README.md
@@ -115,12 +115,10 @@ start MySQL on localhost and give privileges to the user `otptest` and (for
 `ssl_tests`) to the user `otptestssl`:
 
 ```SQL
-CREATE USER otptest@localhost
-  IDENTIFIED WITH 'mysql_native_password' BY 'otptest';
+CREATE USER otptest@localhost IDENTIFIED BY 'otptest';
 GRANT ALL PRIVILEGES ON otptest.* TO otptest@localhost;
 
-CREATE USER otptestssl@localhost
-  IDENTIFIED WITH 'mysql_native_password' BY 'otptestssl' REQUIRE SSL;
+CREATE USER otptestssl@localhost IDENTIFIED BY 'otptestssl' REQUIRE SSL;
 GRANT ALL PRIVILEGES ON otptest.* TO otptestssl@localhost;
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Requirements:
   pattern matching. This was fixed in OTP 21.1.
 * MySQL database version 4.1 or later or MariaDB
 * No other dependencies
+* Authentication method `caching_sha2_password` is not supported. This is the
+  default in MySQL 8.0.4 and later, so you need to add
+  `default_authentication_plugin=mysql_native_password` under `[mysqld]` in e.g.
+  `/etc/mysql/my.cnf`.
 
 Synopsis
 --------
@@ -39,7 +43,8 @@ Synopsis
 %% Connect (ssl is optional)
 {ok, Pid} = mysql:start_link([{host, "localhost"}, {user, "foo"},
                               {password, "hello"}, {database, "test"},
-                              {ssl, [{cacertfile, "/path/to/ca.pem"}]}]),
+                              {ssl, [{server_name_indication, disable},
+                                     {cacertfile, "/path/to/ca.pem"}]}]),
 
 %% Select
 {ok, ColumnNames, Rows} =
@@ -110,8 +115,13 @@ start MySQL on localhost and give privileges to the user `otptest` and (for
 `ssl_tests`) to the user `otptestssl`:
 
 ```SQL
-grant all privileges on otptest.* to otptest@localhost identified by 'otptest';
-grant all privileges on otptest.* to otptestssl@localhost identified by 'otptestssl' require ssl;
+CREATE USER otptest@localhost
+  IDENTIFIED WITH 'mysql_native_password' BY 'otptest';
+GRANT ALL PRIVILEGES ON otptest.* TO otptest@localhost;
+
+CREATE USER otptestssl@localhost
+  IDENTIFIED WITH 'mysql_native_password' BY 'otptestssl' REQUIRE SSL;
+GRANT ALL PRIVILEGES ON otptest.* TO otptestssl@localhost;
 ```
 
 Before running the test suite `ssl_tests` you'll also need to generate SSL files

--- a/test/mysql_tests.erl
+++ b/test/mysql_tests.erl
@@ -29,7 +29,7 @@
 
 %% We need to set a the SQL mode so it is consistent across MySQL versions
 %% and distributions.
--define(SQL_MODE, <<"NO_ENGINE_SUBSTITUTION,NO_AUTO_CREATE_USER">>).
+-define(SQL_MODE, <<"NO_ENGINE_SUBSTITUTION">>).
 
 -define(create_table_t, <<"CREATE TABLE t ("
                           "  id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,"

--- a/test/ssl_tests.erl
+++ b/test/ssl_tests.erl
@@ -1,5 +1,6 @@
 %% MySQL/OTP – MySQL client library for Erlang/OTP
-%% Copyright (C) 2017 Piotr Nosek, Viktor Söderqvist
+%% Copyright (C) 2017 Piotr Nosek
+%% Copyright (C) 2017-2018 Viktor Söderqvist
 %%
 %% This file is part of MySQL/OTP.
 %%
@@ -24,16 +25,11 @@
 -define(ssl_user,     "otptestssl").
 -define(ssl_password, "otptestssl").
 -define(cacertfile,   "test/ssl/ca.pem").
--define(certfile,     "test/ssl/server-cert.pem").
--define(keyfile,      "test/ssl/server-key.pem").
 
 successful_ssl_connect_test() ->
     [ application:start(App) || App <- [crypto, asn1, public_key, ssl] ],
-    common_basic_check([{ssl, [
-                        {server_name_indication, disable}, 
-                        {cacertfile, ?cacertfile}]},
-                        {certfile, ?certfile},
-                        {keyfile, ?keyfile},
+    common_basic_check([{ssl, [{server_name_indication, disable},
+                               {cacertfile, ?cacertfile}]},
                         {user, ?ssl_user}, {password, ?ssl_password}]),
     common_conn_close(),
     ok.


### PR DESCRIPTION
* Add notes in README about unsupported caching_sha2_password.
* Explicitly use mysql_native_password in tests.
* Remove NO_AUTOC_REATE_USER from SQL_MODE as it doesn't exist anymore.
* Deadlock test still failing with MySQL 8.0.13. Implicit commit happens unexpectedly.