### PR TITLE
result filter/map capability

### DIFF
--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -49,14 +49,15 @@
 -type row() :: [term()].
 -type rows() :: [row()].
 
+-type query_filtermap_fun() :: fun((row()) -> query_filtermap_res())
+                             | fun((column_names(), row()) -> query_filtermap_res()).
+-type query_filtermap_res() :: boolean()
+                             | {true, term()}.
+
 -type query_result() :: ok
                       | {ok, column_names(), rows()}
                       | {ok, [{column_names(), rows()}, ...]}
                       | {error, server_reason()}.
-
--type query_filtermap() :: undefined
-                         | fun((row()) -> boolean() | {true, term()})
-                         | fun((column_names(), row()) -> boolean() | {true, term()}).
 
 -define(default_connect_timeout, 5000).
 
@@ -166,101 +167,75 @@ start_link(Options) ->
     end,
     Ret.
 
-%% @doc Executes a query with the query timeout as given to start_link/1.
-%%
-%% It is possible to execute multiple semicolon-separated queries.
-%%
-%% Results are returned in the form `{ok, ColumnNames, Rows}' if there is one
-%% result set. If there are more than one result sets, they are returned in the
-%% form `{ok, [{ColumnNames, Rows}, ...]}'.
-%%
-%% For queries that don't return any rows (INSERT, UPDATE, etc.) only the atom
-%% `ok' is returned.
+%% @see query/5.
 -spec query(Conn, Query) -> Result
     when Conn :: connection(),
          Query :: iodata(),
          Result :: query_result().
 query(Conn, Query) ->
-    query_call(Conn, {query, Query, undefined, undefined}).
+    query(Conn, Query, no_params, no_filtermap_fun, default_timeout).
 
-%% @doc Depending on the 3rd argument this function does different things.
-%%
-%% If the 3rd argument is a list, it executes a parameterized query and applies
-%% no filtering/mapping of the result rows. This is equivallent to query/5
-%% with undefined as filter/map function and the query timeout as given to
-%% start_link/1.
-%%
-%% If the 3rd argumeent is a function, it is used to filter/map the result
-%% rows. This is equivalent to query/4 with the query timeout given to
-%% start_link/1.
-%%
-%% If the 3rd argument is a timeout, it executes a plain query with this
-%% timeout and applies no filtering/mapping of the resultset rows.
-%%
-%% The return value is the same as for query/2.
-%%
-%% @see query/2.
-%% @see query/4.
+%% @see query/5.
 -spec query(Conn, Query, Params | FilterMap | Timeout) -> Result
     when Conn :: connection(),
          Query :: iodata(),
-         Timeout :: timeout(),
-         Params :: [term()],
-         FilterMap :: query_filtermap(),
+         Timeout :: default_timeout | timeout(),
+         Params :: no_params | [term()],
+         FilterMap :: no_filtermap_fun | query_filtermap_fun(),
          Result :: query_result().
-query(Conn, Query, Params) when is_list(Params) ->
-    query_call(Conn, {param_query, Query, Params, undefined, undefined});
-query(Conn, Query, FilterMap) when FilterMap=:=undefined;
-        is_function(FilterMap, 1); is_function(FilterMap, 2) ->
-    query_call(Conn, {query, Query, FilterMap, undefined});
-query(Conn, Query, Timeout) when is_integer(Timeout); Timeout == infinity ->
-    query_call(Conn, {query, Query, undefined, Timeout}).
+query(Conn, Query, Params) when Params == no_params;
+                                is_list(Params) ->
+    query(Conn, Query, Params, no_filtermap_fun, default_timeout);
+query(Conn, Query, FilterMap) when FilterMap == no_filtermap_fun;
+                                   is_function(FilterMap, 1);
+                                   is_function(FilterMap, 2) ->
+    query(Conn, Query, no_params, FilterMap, default_timeout);
+query(Conn, Query, Timeout) when Timeout == default_timeout;
+                                 is_integer(Timeout);
+                                 Timeout == infinity ->
+    query(Conn, Query, no_params, no_filtermap_fun, Timeout).
 
-%% @doc Depending on the 3rd and 4th arguments this function does different
-%% things.
-%%
-%% If either the 3rd argument is a list, a prepared statement is created,
-%% executed and then cached for a certain time. If the same query is executed
-%% again when it is already cached, it does not need to be prepared again.
-%% The minimum time the prepared statement is cached can be specified using the
-%% option `{query_cache_time, Milliseconds}' to start_link/1.
-%% Conversely, if the 3rd argument is not a list, a plain query is executed.
-%%
-%% If the 4th argument is a timeout, the query is executed with that timeout.
-%% Conversely, if the 4th argument is not a timeout, the timeout given in
-%% start_link/1 is used.
-%%
-%% If either the 3rd or 4th argument is a function instead of a list or
-%% timeout, respectively, it is used to filter/map the result rows.
-%%
-%% The return value is the same as for query/2.
+%% @see query/5.
 -spec query(Conn, Query, Params, Timeout) -> Result
         when Conn :: connection(),
              Query :: iodata(),
-             Timeout :: timeout(),
-             Params :: [term()],
+             Timeout :: default_timeout | timeout(),
+             Params :: no_params | [term()],
              Result :: query_result();
     (Conn, Query, FilterMap, Timeout) -> Result
         when Conn :: connection(),
              Query :: iodata(),
-             Timeout :: timeout(),
-             FilterMap :: query_filtermap(),
+             Timeout :: default_timeout | timeout(),
+             FilterMap :: no_filtermap_fun | query_filtermap_fun(),
              Result :: query_result();
     (Conn, Query, Params, FilterMap) -> Result
         when Conn :: connection(),
              Query :: iodata(),
-             Params :: [term()],
-             FilterMap :: query_filtermap(),
+             Params :: no_params | [term()],
+             FilterMap :: no_filtermap_fun | query_filtermap_fun(),
              Result :: query_result().
-query(Conn, Query, Params, Timeout) when is_list(Params) andalso (is_integer(Timeout) orelse Timeout=:=infinity) ->
-    query_call(Conn, {param_query, Query, Params, undefined, Timeout});
-query(Conn, Query, FilterMap, Timeout) when (is_function(FilterMap, 1) orelse is_function(FilterMap, 2)) andalso (is_integer(Timeout) orelse Timeout=:=infinity) ->
-    query_call(Conn, {query, Query, FilterMap, Timeout});
-query(Conn, Query, Params, FilterMap) when is_list(Params) andalso (is_function(FilterMap, 1) orelse is_function(FilterMap, 2)) ->
-    query_call(Conn, {param_query, Query, Params, FilterMap, undefined}).
+query(Conn, Query, Params, Timeout) when (Params == no_params orelse
+                                          is_list(Params)) andalso
+                                         (Timeout == default_timeout orelse
+                                          is_integer(Timeout) orelse
+                                          Timeout == infinity) ->
+    query(Conn, Query, Params, no_filtermap_fun, Timeout);
+query(Conn, Query, FilterMap, Timeout) when (FilterMap == no_filtermap_fun orelse
+                                             is_function(FilterMap, 1) orelse
+                                             is_function(FilterMap, 2)) andalso
+                                            (Timeout == default_timeout orelse
+                                             is_integer(Timeout) orelse
+                                             Timeout=:=infinity) ->
+    query(Conn, Query, no_params, FilterMap, Timeout);
+query(Conn, Query, Params, FilterMap) when (Params == no_params orelse
+                                            is_list(Params)) andalso
+                                           (FilterMap == no_filtermap_fun orelse
+                                            is_function(FilterMap, 1) orelse
+                                            is_function(FilterMap, 2)) ->
+    query(Conn, Query, Params, FilterMap, default_timeout).
 
 %% @doc Executes a parameterized query with a timeout and applies a filter/map
-%% function to the result rows..
+%% function to the result rows.
 %%
 %% A prepared statement is created, executed and then cached for a certain
 %% time. If the same query is executed again when it is already cached, it does
@@ -269,14 +244,84 @@ query(Conn, Query, Params, FilterMap) when is_list(Params) andalso (is_function(
 %% The minimum time the prepared statement is cached can be specified using the
 %% option `{query_cache_time, Milliseconds}' to start_link/1.
 %%
-%% The return value is the same as for query/2.
+%% Results are returned in the form `{ok, ColumnNames, Rows}' if there is one
+%% result set. If there are more than one result sets, they are returned in the
+%% form `{ok, [{ColumnNames, Rows}, ...]}'.
+%%
+%% For queries that don't return any rows (INSERT, UPDATE, etc.) only the atom
+%% `ok' is returned.
+%%
+%% The `Params', `FilterMap' and `Timeout' arguments are optional.
+%% <ul>
+%%   <li>If the `Params' argument is the atom `no_params' or is omitted, a plain
+%%       query will be executed instead of a parameterized one.</li>
+%%   <li>If the `FilterMap' argument is the atom `no_filtermap_fun' or is
+%%       omitted, no row filtering/mapping will be applied and all result rows
+%%       will be returned unchanged.</li>
+%%   <li>If the `Timeout' argument is the atom `default_timeout' or is omitted,
+%%       the timeout given in `start_link/1' is used.</li>
+%% </ul>
+%%
+%% If the `FilterMap' argument is used, it must be a function of arity 1 or 2
+%% that returns either `true', `false', or `{true, Value}'.
+%%
+%% Each result row is handed to the given function as soon as it is received
+%% from the server, and only when the function has returned, the next row is
+%% fetched. This provides the ability to prevent memory exhaustion; on the
+%% other hand, it can cause the server to time out on sending if your function
+%% is doing something slow (see the MySQL documentation on `NET_WRITE_TIMEOUT').
+%%
+%% If the function is of arity 1, only the row is passed to it as the single
+%% argument, while if the function is of arity 2, the column names are passed
+%% in as the first argument and the row as the second.
+%%
+%% The value returned is then used to decide if the row is to be included in
+%% the result(s) returned from the `query' call (filtering), or if something
+%% else is to be included in the result instead (mapping). You may also use
+%% this function for side effects, like writing rows to disk or sending them
+%% to another process etc.
+%%
+%% Here is an example showing some of the things that are possible:
+%% ```
+%% Query = "SELECT `a`, `b`, `c` FROM `foo`",
+%% FilterMap = fun
+%%     %% Include all rows where the first column is < 10.
+%%     ([A|_]) when A < 10 ->
+%%         true;
+%%     %% Exclude all rows where the first column is >= 10 and < 20.
+%%     ([A|_]) when A < 20 ->
+%%         false;
+%%     %% For rows where the first column is >= 20 and < 30, include
+%%     %% the atom 'foo' in place of the row instead.
+%%     ([A|_]) when A < 30 ->
+%%         {true, foo}};
+%%     %% For rows where the first row is >= 30 and < 40, send the
+%%     %% row to a gen_server via call (ie, wait for a response),
+%%     %% and do not include the row in the result.
+%%     (R=[A|_]) when A < 40 ->
+%%         gen_server:call(Pid, R),
+%%         false;
+%%     %% For rows where the first column is >= 40 and < 50, send the
+%%     %% row to a gen_server via cast (ie, do not wait for a reply),
+%%     %% and include the row in the result, also.
+%%     (R=[A|_]) when A < 50 ->
+%%         gen_server:cast(Pid, R),
+%%         true;
+%%     %% Exclude all other rows from the result.
+%%     (_) ->
+%%         false
+%% end,
+%% query(Conn, Query, no_params, FilterMap, default_timeout).
+%% '''
 -spec query(Conn, Query, Params, FilterMap, Timeout) -> Result
     when Conn :: connection(),
          Query :: iodata(),
-         Timeout :: timeout(),
-         Params :: [term()],
-         FilterMap :: query_filtermap(),
+         Timeout :: default_timeout | timeout(),
+         Params :: no_params | [term()],
+         FilterMap :: no_filtermap_fun | query_filtermap_fun(),
          Result :: query_result().
+query(Conn, Query, no_params, FilterMap, Timeout) ->
+    query_call(Conn, {query, Query, FilterMap, Timeout});
 query(Conn, Query, Params, FilterMap, Timeout) ->
     query_call(Conn, {param_query, Query, Params, FilterMap, Timeout}).
 
@@ -285,42 +330,61 @@ query(Conn, Query, Params, FilterMap, Timeout) ->
 %% @see prepare/2
 %% @see prepare/3
 %% @see prepare/4
+%% @see execute/5
 -spec execute(Conn, StatementRef, Params) -> Result | {error, not_prepared}
   when Conn :: connection(),
        StatementRef :: atom() | integer(),
        Params :: [term()],
        Result :: query_result().
 execute(Conn, StatementRef, Params) ->
-    query_call(Conn, {execute, StatementRef, Params, undefined, undefined}).
+    execute(Conn, StatementRef, Params, no_filtermap_fun, default_timeout).
 
 %% @doc Executes a prepared statement.
 %% @see prepare/2
 %% @see prepare/3
 %% @see prepare/4
+%% @see execute/5
 -spec execute(Conn, StatementRef, Params, FilterMap | Timeout) ->
     Result | {error, not_prepared}
   when Conn :: connection(),
        StatementRef :: atom() | integer(),
        Params :: [term()],
-       FilterMap :: query_filtermap(),
-       Timeout :: timeout(),
+       FilterMap :: no_filtermap_fun | query_filtermap_fun(),
+       Timeout :: default_timeout | timeout(),
        Result :: query_result().
-execute(Conn, StatementRef, Params, Timeout) when is_integer(Timeout); Timeout=:=infinity ->
-    query_call(Conn, {execute, StatementRef, Params, undefined, Timeout});
-execute(Conn, StatementRef, Params, FilterMap) when is_function(FilterMap, 1); is_function(FilterMap, 2) ->
-    query_call(Conn, {execute, StatementRef, Params, FilterMap, undefined}).
+execute(Conn, StatementRef, Params, Timeout) when Timeout == default_timeout;
+                                                  is_integer(Timeout);
+                                                  Timeout=:=infinity ->
+    execute(Conn, StatementRef, Params, no_filtermap_fun, Timeout);
+execute(Conn, StatementRef, Params, FilterMap) when FilterMap == no_filtermap_fun;
+                                                    is_function(FilterMap, 1);
+                                                    is_function(FilterMap, 2) ->
+    execute(Conn, StatementRef, Params, FilterMap, default_timeout).
 
 %% @doc Executes a prepared statement.
+%% 
+%% The `FilterMap' and `Timeout' arguments are optional.
+%% <ul>
+%%   <li>If the `FilterMap' argument is the atom `no_filtermap_fun' or is
+%%       omitted, no row filtering/mapping will be applied and all result rows
+%%       will be returned unchanged.</li>
+%%   <li>If the `Timeout' argument is the atom `default_timeout' or is omitted,
+%%       the timeout given in `start_link/1' is used.</li>
+%% </ul>
+%%
+%% See `query/5' for an explanation of the `FilterMap' argument.
+%%
 %% @see prepare/2
 %% @see prepare/3
 %% @see prepare/4
+%% @see query/5
 -spec execute(Conn, StatementRef, Params, FilterMap, Timeout) ->
     Result | {error, not_prepared}
   when Conn :: connection(),
        StatementRef :: atom() | integer(),
        Params :: [term()],
-       FilterMap :: query_filtermap(),
-       Timeout :: timeout(),
+       FilterMap :: no_filtermap_fun | query_filtermap_fun(),
+       Timeout :: default_timeout | timeout(),
        Result :: query_result().
 execute(Conn, StatementRef, Params, FilterMap, Timeout) ->
     query_call(Conn, {execute, StatementRef, Params, FilterMap, Timeout}).

--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -283,7 +283,7 @@ query(Conn, Query, Params, FilterMap) when (Params == no_params orelse
 %%
 %% Here is an example showing some of the things that are possible:
 %% ```
-%% Query = "SELECT `a`, `b`, `c` FROM `foo`",
+%% Query = "SELECT a, b, c FROM foo",
 %% FilterMap = fun
 %%     %% Include all rows where the first column is < 10.
 %%     ([A|_]) when A < 10 ->

--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -119,12 +119,9 @@ init(Opts) ->
 %% Query and execute calls:
 %%
 %% <ul>
-%%   <li>{query, Query}</li>
-%%   <li>{query, Query, Timeout}</li>
-%%   <li>{param_query, Query, Params}</li>
-%%   <li>{param_query, Query, Params, Timeout}</li>
-%%   <li>{execute, Stmt, Args}</li>
-%%   <li>{execute, Stmt, Args, Timeout}</li>
+%%   <li>{query, Query, FilterMap, Timeout}</li>
+%%   <li>{param_query, Query, Params, FilterMap, Timeout}</li>
+%%   <li>{execute, Stmt, Args, FilterMap, Timeout}</li>
 %% </ul>
 %%
 %% For the calls listed above, we return these values:
@@ -154,15 +151,18 @@ init(Opts) ->
 %%       able to handle this in the caller's process, we also return the
 %%       nesting level.</dd>
 %% </dl>
-handle_call({query, Query, FilterMap, undefined}, From, State) ->
-    handle_call({query, Query, FilterMap, State#state.query_timeout}, From, State);
+handle_call({query, Query, FilterMap, default_timeout}, From, State) ->
+    handle_call({query, Query, FilterMap, State#state.query_timeout}, From,
+                State);
 handle_call({query, Query, FilterMap, Timeout}, _From,
             #state{sockmod = SockMod, socket = Socket} = State) ->
     setopts(SockMod, Socket, [{active, false}]),
-    {ok, Recs} = case mysql_protocol:query(Query, SockMod, Socket, FilterMap, Timeout) of
+    Result = mysql_protocol:query(Query, SockMod, Socket, FilterMap, Timeout),
+    {ok, Recs} = case Result of
         {error, timeout} when State#state.server_version >= [5, 0, 0] ->
             kill_query(State),
-            mysql_protocol:fetch_query_response(SockMod, Socket, FilterMap, ?cmd_timeout);
+            mysql_protocol:fetch_query_response(SockMod, Socket, FilterMap,
+                                                ?cmd_timeout);
         {error, timeout} ->
             %% For MySQL 4.x.x there is no way to recover from timeout except
             %% killing the connection itself.
@@ -175,9 +175,10 @@ handle_call({query, Query, FilterMap, Timeout}, _From,
     State1#state.warning_count > 0 andalso State1#state.log_warnings
         andalso log_warnings(State1, Query),
     handle_query_call_reply(Recs, Query, State1, []);
-handle_call({param_query, Query, Params, FilterMap, undefined}, From, State) ->
-    handle_call({param_query, Query, Params, FilterMap, State#state.query_timeout},
-                From, State);
+handle_call({param_query, Query, Params, FilterMap, default_timeout}, From,
+            State) ->
+    handle_call({param_query, Query, Params, FilterMap,
+                State#state.query_timeout}, From, State);
 handle_call({param_query, Query, Params, FilterMap, Timeout}, _From,
             #state{socket = Socket, sockmod = SockMod} = State) ->
     %% Parametrized query: Prepared statement cached with the query as the key
@@ -211,7 +212,7 @@ handle_call({param_query, Query, Params, FilterMap, Timeout}, _From,
         PrepareError ->
             {reply, PrepareError, State}
     end;
-handle_call({execute, Stmt, Args, FilterMap, undefined}, From, State) ->
+handle_call({execute, Stmt, Args, FilterMap, default_timeout}, From, State) ->
     handle_call({execute, Stmt, Args, FilterMap, State#state.query_timeout},
         From, State);
 handle_call({execute, Stmt, Args, FilterMap, Timeout}, _From, State) ->
@@ -383,7 +384,8 @@ code_change(_OldVsn, _State, _Extra) ->
 %% --- Helpers ---
 
 %% @doc Executes a prepared statement and returns {Reply, NextState}.
-execute_stmt(Stmt, Args, FilterMap, Timeout, State = #state{socket = Socket, sockmod = SockMod}) ->
+execute_stmt(Stmt, Args, FilterMap, Timeout,
+             State = #state{socket = Socket, sockmod = SockMod}) ->
     setopts(SockMod, Socket, [{active, false}]),
     {ok, Recs} = case mysql_protocol:execute(Stmt, Args, SockMod, Socket,
                                              FilterMap, Timeout) of

--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -154,15 +154,15 @@ init(Opts) ->
 %%       able to handle this in the caller's process, we also return the
 %%       nesting level.</dd>
 %% </dl>
-handle_call({query, Query}, From, State) ->
-    handle_call({query, Query, State#state.query_timeout}, From, State);
-handle_call({query, Query, Timeout}, _From,
+handle_call({query, Query, FilterMap, undefined}, From, State) ->
+    handle_call({query, Query, FilterMap, State#state.query_timeout}, From, State);
+handle_call({query, Query, FilterMap, Timeout}, _From,
             #state{sockmod = SockMod, socket = Socket} = State) ->
     setopts(SockMod, Socket, [{active, false}]),
-    {ok, Recs} = case mysql_protocol:query(Query, SockMod, Socket, Timeout) of
+    {ok, Recs} = case mysql_protocol:query(Query, SockMod, Socket, FilterMap, Timeout) of
         {error, timeout} when State#state.server_version >= [5, 0, 0] ->
             kill_query(State),
-            mysql_protocol:fetch_query_response(SockMod, Socket, ?cmd_timeout);
+            mysql_protocol:fetch_query_response(SockMod, Socket, FilterMap, ?cmd_timeout);
         {error, timeout} ->
             %% For MySQL 4.x.x there is no way to recover from timeout except
             %% killing the connection itself.
@@ -175,10 +175,10 @@ handle_call({query, Query, Timeout}, _From,
     State1#state.warning_count > 0 andalso State1#state.log_warnings
         andalso log_warnings(State1, Query),
     handle_query_call_reply(Recs, Query, State1, []);
-handle_call({param_query, Query, Params}, From, State) ->
-    handle_call({param_query, Query, Params, State#state.query_timeout}, From,
-                State);
-handle_call({param_query, Query, Params, Timeout}, _From,
+handle_call({param_query, Query, Params, FilterMap, undefined}, From, State) ->
+    handle_call({param_query, Query, Params, FilterMap, State#state.query_timeout},
+                From, State);
+handle_call({param_query, Query, Params, FilterMap, Timeout}, _From,
             #state{socket = Socket, sockmod = SockMod} = State) ->
     %% Parametrized query: Prepared statement cached with the query as the key
     QueryBin = iolist_to_binary(Query),
@@ -207,16 +207,17 @@ handle_call({param_query, Query, Params, Timeout}, _From,
     case StmtResult of
         {ok, StmtRec} ->
             State1 = State#state{query_cache = Cache1},
-            execute_stmt(StmtRec, Params, Timeout, State1);
+            execute_stmt(StmtRec, Params, FilterMap, Timeout, State1);
         PrepareError ->
             {reply, PrepareError, State}
     end;
-handle_call({execute, Stmt, Args}, From, State) ->
-    handle_call({execute, Stmt, Args, State#state.query_timeout}, From, State);
-handle_call({execute, Stmt, Args, Timeout}, _From, State) ->
+handle_call({execute, Stmt, Args, FilterMap, undefined}, From, State) ->
+    handle_call({execute, Stmt, Args, FilterMap, State#state.query_timeout},
+        From, State);
+handle_call({execute, Stmt, Args, FilterMap, Timeout}, _From, State) ->
     case dict:find(Stmt, State#state.stmts) of
         {ok, StmtRec} ->
-            execute_stmt(StmtRec, Args, Timeout, State);
+            execute_stmt(StmtRec, Args, FilterMap, Timeout, State);
         error ->
             {reply, {error, not_prepared}, State}
     end;
@@ -382,14 +383,14 @@ code_change(_OldVsn, _State, _Extra) ->
 %% --- Helpers ---
 
 %% @doc Executes a prepared statement and returns {Reply, NextState}.
-execute_stmt(Stmt, Args, Timeout, State = #state{socket = Socket, sockmod = SockMod}) ->
+execute_stmt(Stmt, Args, FilterMap, Timeout, State = #state{socket = Socket, sockmod = SockMod}) ->
     setopts(SockMod, Socket, [{active, false}]),
     {ok, Recs} = case mysql_protocol:execute(Stmt, Args, SockMod, Socket,
-                                             Timeout) of
+                                             FilterMap, Timeout) of
         {error, timeout} when State#state.server_version >= [5, 0, 0] ->
             kill_query(State),
             mysql_protocol:fetch_execute_response(SockMod, Socket,
-                                                  ?cmd_timeout);
+                                                  FilterMap, ?cmd_timeout);
         {error, timeout} ->
             %% For MySQL 4.x.x there is no way to recover from timeout except
             %% killing the connection itself.

--- a/src/mysql_protocol.erl
+++ b/src/mysql_protocol.erl
@@ -28,8 +28,15 @@
 -module(mysql_protocol).
 
 -export([handshake/7, quit/2, ping/2,
-         query/4, fetch_query_response/3,
-         prepare/3, unprepare/3, execute/5, fetch_execute_response/3]).
+         query/4, query/5, fetch_query_response/3,
+         fetch_query_response/4, prepare/3, unprepare/3,
+         execute/5, execute/6, fetch_execute_response/3,
+         fetch_execute_response/4]).
+
+-type query_filtermap() :: undefined
+                         | fun(([term()]) -> query_filtermap_result())
+                         | fun(([term()], [term()]) -> query_filtermap_result()).
+-type query_filtermap_result() :: boolean() | {true, term()}.
 
 %% How much data do we want per packet?
 -define(MAX_BYTES_PER_PACKET, 16#1000000).
@@ -113,15 +120,23 @@ ping(SockModule, Socket) ->
 -spec query(Query :: iodata(), atom(), term(), timeout()) ->
     {ok, [#ok{} | #resultset{} | #error{}]} | {error, timeout}.
 query(Query, SockModule, Socket, Timeout) ->
+    query(Query, SockModule, Socket, undefined, Timeout).
+
+-spec query(Query :: iodata(), atom(), term(), query_filtermap(), timeout()) ->
+    {ok, [#ok{} | #resultset{} | #error{}]} | {error, timeout}.
+query(Query, SockModule, Socket, FilterMapFun, Timeout) ->
     Req = <<?COM_QUERY, (iolist_to_binary(Query))/binary>>,
     SeqNum0 = 0,
     {ok, _SeqNum1} = send_packet(SockModule, Socket, Req, SeqNum0),
-    fetch_query_response(SockModule, Socket, Timeout).
+    fetch_query_response(SockModule, Socket, FilterMapFun, Timeout).
 
 %% @doc This is used by query/4. If query/4 returns {error, timeout}, this
 %% function can be called to retry to fetch the results of the query.
 fetch_query_response(SockModule, Socket, Timeout) ->
-    fetch_response(SockModule, Socket, Timeout, text, []).
+    fetch_query_response(SockModule, Socket, undefined, Timeout).
+
+fetch_query_response(SockModule, Socket, FilterMapFun, Timeout) ->
+    fetch_response(SockModule, Socket, Timeout, text, FilterMapFun, []).
 
 %% @doc Prepares a statement.
 -spec prepare(iodata(), atom(), term()) -> #error{} | #prepared{}.
@@ -168,8 +183,12 @@ unprepare(#prepared{statement_id = Id}, SockModule, Socket) ->
 %% @doc Executes a prepared statement.
 -spec execute(#prepared{}, [term()], atom(), term(), timeout()) ->
     {ok, [#ok{} | #resultset{} | #error{}]} | {error, timeout}.
+execute(PrepStmt, ParamValues, SockModule, Socket, Timeout) ->
+    execute(PrepStmt, ParamValues, SockModule, Socket, undefined, Timeout).
+-spec execute(#prepared{}, [term()], atom(), term(), query_filtermap(), timeout()) ->
+    {ok, [#ok{} | #resultset{} | #error{}]} | {error, timeout}.
 execute(#prepared{statement_id = Id, param_count = ParamCount}, ParamValues,
-        SockModule, Socket, Timeout) when ParamCount == length(ParamValues) ->
+        SockModule, Socket, FilterMapFun, Timeout) when ParamCount == length(ParamValues) ->
     %% Flags Constant Name
     %% 0x00 CURSOR_TYPE_NO_CURSOR
     %% 0x01 CURSOR_TYPE_READ_ONLY
@@ -196,12 +215,15 @@ execute(#prepared{statement_id = Id, param_count = ParamCount}, ParamValues,
             iolist_to_binary([Req1, TypesAndSigns, EncValues])
     end,
     {ok, _SeqNum1} = send_packet(SockModule, Socket, Req, 0),
-    fetch_execute_response(SockModule, Socket, Timeout).
+    fetch_execute_response(SockModule, Socket, FilterMapFun, Timeout).
 
 %% @doc This is used by execute/5. If execute/5 returns {error, timeout}, this
 %% function can be called to retry to fetch the results of the query.
 fetch_execute_response(SockModule, Socket, Timeout) ->
-    fetch_response(SockModule, Socket, Timeout, binary, []).
+    fetch_execute_response(SockModule, Socket, undefined, Timeout).
+
+fetch_execute_response(SockModule, Socket, FilterMapFun, Timeout) ->
+    fetch_response(SockModule, Socket, Timeout, binary, FilterMapFun, []).
 
 %% --- internal ---
 
@@ -413,9 +435,9 @@ parse_handshake_confirm(Packet) ->
 %% @doc Fetches one or more results and and parses the result set(s) using
 %% either the text format (for plain queries) or the binary format (for
 %% prepared statements).
--spec fetch_response(atom(), term(), timeout(), text | binary, list()) ->
+-spec fetch_response(atom(), term(), timeout(), text | binary, query_filtermap(), list()) ->
     {ok, [#ok{} | #resultset{} | #error{}]} | {error, timeout}.
-fetch_response(SockModule, Socket, Timeout, Proto, Acc) ->
+fetch_response(SockModule, Socket, Timeout, Proto, FilterMapFun, Acc) ->
     case recv_packet(SockModule, Socket, Timeout, any) of
         {ok, Packet, SeqNum2} ->
             Result = case Packet of
@@ -426,12 +448,12 @@ fetch_response(SockModule, Socket, Timeout, Proto, Acc) ->
                 ResultPacket ->
                     %% The first packet in a resultset is only the column count.
                     {ColCount, <<>>} = lenenc_int(ResultPacket),
-                    fetch_resultset(SockModule, Socket, ColCount, Proto, SeqNum2)
+                    fetch_resultset(SockModule, Socket, ColCount, Proto, FilterMapFun, SeqNum2)
             end,
             Acc1 = [Result | Acc],
             case more_results_exists(Result) of
                 true ->
-                    fetch_response(SockModule, Socket, Timeout, Proto, Acc1);
+                    fetch_response(SockModule, Socket, Timeout, Proto, FilterMapFun, Acc1);
                 false ->
                     {ok, lists:reverse(Acc1)}
             end;
@@ -440,14 +462,14 @@ fetch_response(SockModule, Socket, Timeout, Proto, Acc) ->
     end.
 
 %% @doc Fetches a result set.
--spec fetch_resultset(atom(), term(), integer(), text | binary, integer()) ->
+-spec fetch_resultset(atom(), term(), integer(), text | binary, query_filtermap(), integer()) ->
     #resultset{} | #error{}.
-fetch_resultset(SockModule, Socket, FieldCount, Proto, SeqNum0) ->
+fetch_resultset(SockModule, Socket, FieldCount, Proto, FilterMapFun, SeqNum0) ->
     {ok, ColDefs0, SeqNum1} = fetch_column_definitions(SockModule, Socket, SeqNum0, FieldCount, []),
     {ok, DelimPacket, SeqNum2} = recv_packet(SockModule, Socket, SeqNum1),
     #eof{status = S, warning_count = W} = parse_eof_packet(DelimPacket),
     ColDefs1 = lists:map(fun parse_column_definition/1, ColDefs0),
-    case fetch_resultset_rows(SockModule, Socket, FieldCount, ColDefs1, Proto, SeqNum2, []) of
+    case fetch_resultset_rows(SockModule, Socket, FieldCount, ColDefs1, Proto, FilterMapFun, SeqNum2, []) of
         {ok, Rows, _SeqNum3} ->
             #resultset{cols = ColDefs1, rows = Rows, status = S, warning_count = W};
         #error{} = E ->
@@ -456,9 +478,9 @@ fetch_resultset(SockModule, Socket, FieldCount, Proto, SeqNum0) ->
 
 %% @doc Fetches the rows for a result set and decodes them using either the text
 %% format (for plain queries) or binary format (for prepared statements).
--spec fetch_resultset_rows(atom(), term(), integer(), [#col{}], text | binary, integer(), [[term()]]) ->
+-spec fetch_resultset_rows(atom(), term(), integer(), [#col{}], text | binary, query_filtermap(), integer(), [[term()]]) ->
     {ok, [[term()]], integer()} | #error{}.
-fetch_resultset_rows(SockModule, Socket, FieldCount, ColDefs, Proto, SeqNum0, Acc) ->
+fetch_resultset_rows(SockModule, Socket, FieldCount, ColDefs, Proto, FilterMapFun, SeqNum0, Acc) ->
     {ok, Packet, SeqNum1} = recv_packet(SockModule, Socket, SeqNum0),
     case Packet of
         ?error_pattern ->
@@ -466,9 +488,24 @@ fetch_resultset_rows(SockModule, Socket, FieldCount, ColDefs, Proto, SeqNum0, Ac
         ?eof_pattern ->
             {ok, lists:reverse(Acc), SeqNum1};
         RowPacket ->
-            Row=decode_row(FieldCount, ColDefs, RowPacket, Proto),
-            fetch_resultset_rows(SockModule, Socket, FieldCount, ColDefs, Proto, SeqNum1, [Row|Acc])
+            Row0=decode_row(FieldCount, ColDefs, RowPacket, Proto),
+            case filtermap_resultset_row(FilterMapFun, ColDefs, Row0) of
+                false -> 
+                    fetch_resultset_rows(SockModule, Socket, FieldCount, ColDefs, Proto, FilterMapFun, SeqNum1, Acc);
+                true ->
+                    fetch_resultset_rows(SockModule, Socket, FieldCount, ColDefs, Proto, FilterMapFun, SeqNum1, [Row0|Acc]);
+                {true, Row1} ->
+                    fetch_resultset_rows(SockModule, Socket, FieldCount, ColDefs, Proto, FilterMapFun, SeqNum1, [Row1|Acc])
+            end
     end.
+
+-spec filtermap_resultset_row(query_filtermap(), [#col{}], [term()]) -> query_filtermap_result().
+filtermap_resultset_row(undefined, _, _) ->
+    true;
+filtermap_resultset_row(Fun, _, Row) when is_function(Fun, 1) ->
+    Fun(Row);
+filtermap_resultset_row(Fun, ColDefs, Row) when is_function(Fun, 2) ->
+    Fun([Col#col.name || Col <- ColDefs], Row).
 
 more_results_exists(#ok{status = S}) ->
     S band ?SERVER_MORE_RESULTS_EXISTS /= 0;


### PR DESCRIPTION
This PR adds the capability to pass a one-ary or two-ary function along with `query` and `execute` calls, to be used somewhat like `lists:filtermap/2`, as discussed in Issue #94.

Result rows will be passed to this function during fetching. The output of the function determines if the row is included or excluded from the result (filter capability), and may at the same time transform the row into something else (mapping capability). The function may also use side effects, eg send the row to another process, write to a file, insert into `ets` tables, etc. An important point is that rows are fetched and decoded only as fast as the function handles them (may be fast if it does some simple filtering or mapping or asynchronously hands them off to another process, or slow if it needs to do complicated things or stuff that is slow by nature), so it can also work as a throttling mechanism to prevent flooding memory with data that is needed only temporarily (ie, not all at once).

To achieve this behavior, it was necessary to change the response fetching strategy (`mysql_protocol:fetch_response` etc). Before, it was like this:
* Fetch _all_ row packets of a result set
* Decode the rows
* Repeat for the next result set until there are none left in the response

Now, it has been changed to:
* Fetch 1 row packet of a result set
* Decode this row packet to a row
* Pass the decoded row to the filtermap function, and depending on the return value (mimicking `lists:filtermap/2` behavior):
  * if `true`, keep the row (to return later as the return of the `query` or `execute` call) as is
  * if `false`, drop the row
  * if `{true, Value}`, keep `Value` instead of the original row (to return later)
* Repeat for next row until there are no more row packets in the result set
* Repeat for the next result set until there are none left in the response