### PR TITLE
implement COM_CHANGE_USER

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ before_script:
   - sleep 5
   - mysql -uroot -e "CREATE USER otptest@localhost IDENTIFIED BY 'otptest';"
   - mysql -uroot -e "GRANT ALL PRIVILEGES ON otptest.* TO otptest@localhost;"
+  - mysql -uroot -e "CREATE USER otptest2@localhost IDENTIFIED BY 'otptest2';"
+  - mysql -uroot -e "GRANT ALL PRIVILEGES ON otptest.* TO otptest2@localhost;"
   - mysql -uroot -e "CREATE USER otptestssl@localhost IDENTIFIED BY 'otptestssl';"
   - mysql -uroot -e "GRANT ALL PRIVILEGES ON otptest.* TO otptestssl@localhost REQUIRE SSL;"
 script: 'make tests'

--- a/README.md
+++ b/README.md
@@ -111,12 +111,15 @@ The encode and protocol test suites does not require a
 running MySQL server on localhost.
 
 For the suites `mysql_tests`, `ssl_tests` and `transaction_tests` you need to
-start MySQL on localhost and give privileges to the user `otptest` and (for
-`ssl_tests`) to the user `otptestssl`:
+start MySQL on localhost and give privileges to the users `otptest`, `otptest2`
+and (for `ssl_tests`) to the user `otptestssl`:
 
 ```SQL
 CREATE USER otptest@localhost IDENTIFIED BY 'otptest';
 GRANT ALL PRIVILEGES ON otptest.* TO otptest@localhost;
+
+CREATE USER otptest2@localhost IDENTIFIED BY 'otptest2';
+GRANT ALL PRIVILEGES ON otptest.* TO otptest2@localhost;
 
 CREATE USER otptestssl@localhost IDENTIFIED BY 'otptestssl';
 GRANT ALL PRIVILEGES ON otptest.* TO otptestssl@localhost REQUIRE SSL;

--- a/test/mysql_change_user_tests.erl
+++ b/test/mysql_change_user_tests.erl
@@ -1,0 +1,153 @@
+%% MySQL/OTP – MySQL client library for Erlang/OTP
+%% Copyright (C) 2014 Viktor Söderqvist
+%%
+%% This file is part of MySQL/OTP.
+%%
+%% MySQL/OTP is free software: you can redistribute it and/or modify it under
+%% the terms of the GNU Lesser General Public License as published by the Free
+%% Software Foundation, either version 3 of the License, or (at your option)
+%% any later version.
+%%
+%% This program is distributed in the hope that it will be useful, but WITHOUT
+%% ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+%% more details.
+%%
+%% You should have received a copy of the GNU Lesser General Public License
+%% along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+%% @doc This module performs test to an actual database.
+-module(mysql_change_user_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(user1,     "otptest").
+-define(password1, "otptest").
+-define(user2,     "otptest2").
+-define(password2, "otptest2").
+
+%% Ensure that the current user can be changed to another user
+%% when given correct credentials.
+correct_credentials_test() ->
+    Pid = connect_db(?user1),
+    ?assertEqual(ok, mysql:change_user(Pid, ?user2, ?password2)),
+    ?assert(is_current_user(Pid, ?user2)),
+    close_conn(Pid),
+    ok.
+
+%% Ensure that change user fails when given incorrect credentials,
+%% and that the current user still works.
+incorrect_credentials_fail_test() ->
+    Pid = connect_db(?user1),
+    TrapExit = erlang:process_flag(trap_exit, true),
+    ?assertError({1045, <<"28000">>, <<"Access denied", _/binary>>},
+                 mysql:change_user(Pid, ?user2, ?password1)),
+    ExitReason = receive {'EXIT', Pid, Reason} -> Reason after 1000 -> error(timeout) end,
+    erlang:process_flag(trap_exit, TrapExit),
+    ?assertEqual(change_user_failed, ExitReason),
+    close_conn(Pid),
+    ok.
+
+%% Ensure that user variables are reset after a successful change user
+%% operation.
+reset_variables_test() ->
+    Pid = connect_db(?user1),
+    ok = mysql:query(Pid, <<"SET @foo=123">>),
+    ?assertEqual(ok, mysql:change_user(Pid, ?user2, ?password2)),
+    ?assert(is_current_user(Pid, ?user2)),
+    ?assertEqual({ok,
+                  [<<"@foo">>],
+                  [[null]]},
+                 mysql:query(Pid, <<"SELECT @foo">>)),
+    close_conn(Pid),
+    ok.
+
+%% Ensure that temporary tables are reset after a successful change user
+%% operation.
+reset_temptables_test() ->
+    Pid = connect_db(?user1),
+    ok = mysql:query(Pid, <<"CREATE DATABASE IF NOT EXISTS otptest">>),
+    ok = mysql:query(Pid, <<"CREATE TEMPORARY TABLE otptest.foo (bar INT)">>),
+    ?assertEqual(ok, mysql:change_user(Pid, ?user2, ?password2)),
+    ?assert(is_current_user(Pid, ?user2)),
+    ?assertMatch({error,
+                  {1146, <<"42S02">>, _}},
+                 mysql:query(Pid, <<"SELECT * FROM otptest.foo">>)),
+    ok = mysql:query(Pid, <<"DROP DATABASE IF EXISTS otptest">>),
+    close_conn(Pid),
+    ok.
+
+%% Ensure that change user fails when inside an unmanaged transaction.
+fail_in_unmanaged_transaction_test() ->
+    Pid = connect_db(?user1),
+    ok = mysql:query(Pid, <<"BEGIN">>),
+    ?assert(mysql:in_transaction(Pid)),
+    ?assertError(change_user_in_transaction,
+                 mysql:change_user(Pid, ?user2, ?password2)),
+    ?assert(is_current_user(Pid, ?user1)),
+    ?assert(mysql:in_transaction(Pid)),
+    close_conn(Pid),
+    ok.
+
+%% Ensure that change user fails when inside a managed transaction.
+fail_in_managed_transaction_test() ->
+    Pid = connect_db(?user1),
+    ?assertError(change_user_in_transaction,
+                 mysql:transaction(Pid,
+                                   fun () -> mysql:change_user(Pid,
+                                                               ?user2,
+                                                               ?password2)
+                                   end)),
+    ?assert(is_current_user(Pid, ?user1)),
+    close_conn(Pid),
+    ok.
+
+with_db_test() ->
+    Pid = connect_db(?user1),
+    ok = mysql:query(Pid, <<"CREATE DATABASE IF NOT EXISTS otptest">>),
+    ?assertEqual(ok, mysql:change_user(Pid, ?user2, ?password2, [{database, <<"otptest">>}])),
+    ?assert(is_current_user(Pid, ?user2)),
+    ?assertEqual({ok,
+                  [<<"DATABASE()">>],
+                  [[<<"otptest">>]]},
+                 mysql:query(Pid, <<"SELECT DATABASE()">>)),
+    ok = mysql:query(Pid, <<"DROP DATABASE IF EXISTS otptest">>),
+    close_conn(Pid),
+    ok.
+
+execute_queries_test() ->
+    Pid = connect_db(?user1),
+    ?assertEqual(ok, mysql:change_user(Pid, ?user2, ?password2, [{queries, [<<"SET @foo=123">>]}])),
+    ?assert(is_current_user(Pid, ?user2)),
+    ?assertEqual({ok,
+                  [<<"@foo">>],
+                  [[123]]},
+                 mysql:query(Pid, <<"SELECT @foo">>)),
+    close_conn(Pid),
+    ok.
+
+prepare_statements_test() ->
+    Pid = connect_db(?user1),
+    ?assertEqual(ok, mysql:change_user(Pid, ?user2, ?password2, [{prepare, [{foo, <<"SELECT ? AS foo">>}]}])),
+    ?assert(is_current_user(Pid, ?user2)),
+    ?assertEqual({ok,
+                  [<<"foo">>],
+                  [[123]]},
+                 mysql:execute(Pid, foo, [123])),
+    close_conn(Pid),
+    ok.
+
+
+connect_db(User) ->
+    {ok, Pid} = mysql:start_link([{user, User}, {password, ?password1},
+                                  {log_warnings, false}]),
+    Pid.
+
+close_conn(Pid) ->
+    exit(Pid, normal).
+
+is_current_user(Pid, User) when is_binary(User) ->
+    {ok, [<<"CURRENT_USER()">>], [[CurUser]]}=mysql:query(Pid, <<"SELECT CURRENT_USER()">>),
+    <<User/binary, "@localhost">> =:= CurUser;
+is_current_user(Pid, User) ->
+    is_current_user(Pid, iolist_to_binary(User)).

--- a/test/mysql_change_user_tests.erl
+++ b/test/mysql_change_user_tests.erl
@@ -1,5 +1,5 @@
 %% MySQL/OTP – MySQL client library for Erlang/OTP
-%% Copyright (C) 2014 Viktor Söderqvist
+%% Copyright (C) 2019 Jan Uhlig
 %%
 %% This file is part of MySQL/OTP.
 %%


### PR DESCRIPTION
This PR implements the `COM_CHANGE_USER` capability which allows changing of the MySQL user on an active connection, ie without closing and re-opening the connection. This is mainly useful if `mysql-otp` is to be used in a connection pool.

This is a work in progress, so there are no tests yet and no documentation beyond the bare specs. Also, some things can certainly be made prettier, for example the duplications in the queries/prepares after connect could be moved to a separate function, and part of the typespecs of `start_link/1` could be unified with that of `change_user/4`.

If the transition is successful, the connection is forthwith owned by the new user; if it fails, it stays with the old user. However it turns out, the session state is reset both in case of success and failure, ie user variables, prepared statements, temporary tables etc will be lost. One could think of the whole process as logging out the old user, attempting login with the new user, and if it fails, re-login with the old user.

So, obviously, active transactions are implicitly rolled back. Some of the other commands in `mysql-otp` notify that this happened by returning something like `implicit_rollback` (or `implicit_commit` for that matter). I didn't do that here, I believe this should be in the documentation only.

A point that may cause confusion and should therefore be documented concerns on-connect queries and prepares. As the ones given in the initial `start_link/1` (or a previous `change_user/4`, see below) are most likely of no use, actually even rather dangerous, after changing the user, those are not run again. Instead, new ones can be given via `change_user/4`. Those are only run if the change was _successful_, but the old ones are _not run again if the change failed_, as, again, this is dangerous. But a user may set some user or session variables with an on-connect query and expect them to be still there after user change failure, which is not the case.

I refrained from offering the possibility to set a timeout for the process, since that might also be dangerous. When the `KILL` reaches the server, the user change may or may not have happened, so it would be uncertain what user the connection is under after a timeout. The switch should happen quickly in normal circumstances, if it doesn't, something else is likely wrong.