### PR TITLE
clean connection stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ end
 {ok, [<<"SLEEP(5)">>], [[1]]} =
     mysql:query(Pid, <<"SELECT SLEEP(5)">>, 1000),
 
-%% Close the connection; make it exit normally
-exit(Pid, normal).
+%% Close the connection
+mysql:stop(Pid).
 ```
 
 Usage as a dependency

--- a/test/ssl_tests.erl
+++ b/test/ssl_tests.erl
@@ -47,12 +47,4 @@ common_basic_check(ExtraOpts) ->
 
 common_conn_close() ->
     Pid = whereis(tardis),
-    process_flag(trap_exit, true),
-    exit(Pid, normal),
-    receive
-        {'EXIT', Pid, normal} -> ok
-    after
-        5000 -> error({cant_stop_connection, Pid})
-    end,
-    process_flag(trap_exit, false).
-
+    mysql:stop(Pid, 5000).

--- a/test/transaction_tests.erl
+++ b/test/transaction_tests.erl
@@ -38,7 +38,7 @@ single_connection_test_() ->
      end,
      fun (Pid) ->
          ok = mysql:query(Pid, <<"DROP DATABASE otptest">>),
-         exit(Pid, normal)
+         mysql:stop(Pid)
      end,
      fun (Pid) ->
          [{"Simple atomic",        fun () -> simple_atomic(Pid) end},
@@ -118,7 +118,7 @@ application_process_kill() ->
     ?assertMatch({ok, _, []},
                  mysql:query(Pid2, <<"SELECT * from foo where bar = 42">>)),
     ok = mysql:query(Pid2, <<"DROP DATABASE otptest">>),
-    exit(Pid2, normal).
+    mysql:stop(Pid2).
 
 simple_atomic(Pid) ->
     ?assertNot(mysql:in_transaction(Pid)),
@@ -207,8 +207,8 @@ deadlock_test_() ->
      end,
      fun ({Conn1, Conn2}) ->
          ok = mysql:query(Conn1, <<"DROP DATABASE otptest">>, 1000),
-         exit(Conn1, normal),
-         exit(Conn2, normal)
+         mysql:stop(Conn1),
+         mysql:stop(Conn2)
      end,
      fun (Conns) ->
          [{"Plain queries", fun () -> deadlock_plain_queries(Conns) end},


### PR DESCRIPTION
Up to now, the way to close a `mysql-otp` connection was via `exit/2`. This has always bothered me TBH, there should be an API function, like `mysql:stop`, for this.

OTP 18 introduced [`gen_server:stop/{1,3}`](http://erlang.org/doc/man/gen_server.html#stop-1), which can be used to stop a `gen_server` in a clean manner, a nice fit for this. As `mysql-otp` wants to support older OTP versions as well, however, this PR provides a workaround in case `gen_server:stop/3` is not available, mimicking it's behavior (but is not quite as clean):
* monitor the connection process
* send an exit signal with reason `normal` to the connection
* waiting for the down message
  * if the down message has `normal` for reason, `ok` is returned
  * if the down message has any other reason (eg `noproc`), an exit exception is raised with the reason from the down message
  * if no down message is received within the specified timeout, the connection is demonitored and an exit exception with reason `timeout` is raised (this does not mean that the connection process will not stop at all, only that it didn't within the given timeout)

The behavior of `mysql:stop/{1,3}` differs from what can be achieved with `exit/2` in that it is _synchronous_, ie the calling process will block until it has finished or timed out. To easily enable asynchronous stopping, a convenience function `mysql:stop_async/1` is in the PR also, which will call `stop` with timeout `infinity` in a spawned process and immediately return `ok`. Other than with synchronous `stop`, none of the errors will reach the process calling `stop_async`, and there is no easy way (apart from sth like `erlang:is_process_alive/1`) to determine if and when the connection closed.