### PR TITLE
Parameter validation for prepared statements and parameterized queries

### DIFF
--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -357,7 +357,13 @@ query(Conn, Query, Params, FilterMap) when (Params == no_params orelse
 query(Conn, Query, no_params, FilterMap, Timeout) ->
     query_call(Conn, {query, Query, FilterMap, Timeout});
 query(Conn, Query, Params, FilterMap, Timeout) ->
-    query_call(Conn, {param_query, Query, Params, FilterMap, Timeout}).
+    case mysql_protocol:valid_params(Params) of
+        true ->
+            query_call(Conn,
+                       {param_query, Query, Params, FilterMap, Timeout});
+        false ->
+            error(badarg)
+    end.
 
 %% @doc Executes a prepared statement with the default query timeout as given
 %% to start_link/1.
@@ -421,7 +427,13 @@ execute(Conn, StatementRef, Params, FilterMap) when FilterMap == no_filtermap_fu
        Timeout :: default_timeout | timeout(),
        Result :: query_result().
 execute(Conn, StatementRef, Params, FilterMap, Timeout) ->
-    query_call(Conn, {execute, StatementRef, Params, FilterMap, Timeout}).
+    case mysql_protocol:valid_params(Params) of
+        true ->
+            query_call(Conn,
+                       {execute, StatementRef, Params, FilterMap, Timeout});
+        false ->
+            error(badarg)
+    end.
 
 %% @doc Creates a prepared statement from the passed query.
 %% @see prepare/3
@@ -729,5 +741,3 @@ query_call(Conn, CallReq) ->
         Result ->
             Result
     end.
-
-

--- a/test/mysql_tests.erl
+++ b/test/mysql_tests.erl
@@ -213,7 +213,8 @@ query_test_() ->
           {"TIME",                 fun () -> time(Pid) end},
           {"DATETIME",             fun () -> datetime(Pid) end},
           {"JSON",                 fun () -> json(Pid) end},
-          {"Microseconds",         fun () -> microseconds(Pid) end}]
+          {"Microseconds",         fun () -> microseconds(Pid) end},
+          {"Invalid params",       fun () -> invalid_params(Pid) end}]
      end}.
 
 connect_with_db(_Pid) ->
@@ -684,6 +685,12 @@ test_datetime_microseconds(Pid) ->
                            <<"dt">>),
     ok = mysql:query(Pid, "DROP TABLE dt").
 
+invalid_params(Pid) ->
+    {ok, StmtId} = mysql:prepare(Pid, "SELECT ?"),
+    ?assertError(badarg, mysql:execute(Pid, StmtId, [x])),
+    ?assertError(badarg, mysql:query(Pid, "SELECT ?", [x])),
+    ok = mysql:unprepare(Pid, StmtId).
+
 %% @doc Tests write and read in text and the binary protocol, all combinations.
 %% This helper function assumes an empty table with a single column.
 write_read_text_binary(Conn, Term, SqlLiteral, Table, Column) ->
@@ -801,7 +808,7 @@ parameterized_query(Conn) ->
     {ok, _, []} = mysql:query(Conn, "SELECT * FROM foo WHERE bar = ?", [2]),
     receive after 150 -> ok end, %% Now the query cache should emptied
     {ok, _, []} = mysql:query(Conn, "SELECT * FROM foo WHERE bar = ?", [3]),
-    {error, {_, _, _}} = mysql:query(Conn, "Lorem ipsum dolor sit amet", [x]).
+    {error, {_, _, _}} = mysql:query(Conn, "Lorem ipsum dolor sit amet", [4]).
 
 %% --- simple gen_server callbacks ---
 


### PR DESCRIPTION
The connection process crashed when invalid parameters were given to a parameterized query or to the execution of a prepared statement (see #66).

The additions in this PR will check the parameters for suitability and raise an `error` exception with reason `badarg` if one of them is invalid.

I'm not entirely happy with the unicode check, but I'm currently unable to come up with another safe way to do that.