### PR TITLE
Stop connection process when post-connect queries or prepares fail

### DIFF
--- a/test/mysql_tests.erl
+++ b/test/mysql_tests.erl
@@ -206,6 +206,27 @@ unix_socket_test() ->
                                   "release could not be determined.~n")
     end.
     
+connect_queries_failure_test() ->
+    process_flag(trap_exit, true),
+    ?assertError(_Reason, mysql:start_link([{user, ?user}, {password, ?password},
+                                            {queries, ["foo"]}])),
+    receive
+        {'EXIT', _Pid, normal} -> ok
+    after 1000 ->
+        error(no_exit_message)
+    end,
+    process_flag(trap_exit, false).
+
+connect_prepare_failure_test() ->
+    process_flag(trap_exit, true),
+    ?assertError(_Reason, mysql:start_link([{user, ?user}, {password, ?password},
+                                            {prepare, [{foo, "foo"}]}])),
+    receive
+        {'EXIT', _Pid, normal} -> ok
+    after 1000 ->
+        error(no_exit_message)
+    end,
+    process_flag(trap_exit, false).
 
 %% For R16B where sys:get_state/1 is not available.
 get_state(Process) ->


### PR DESCRIPTION
This PR addresses the issue outlined in #54.

When one of the post-connect queries or prepares fails, the connection process will now be stopped again via `mysql:stop`, and an `exit` exception will be raised with the error code and message caused by the faulty query/prepare. The same will happen when there are failures in queries/prepares given to `change_user`.

It may be worth mentioning that all queries before a failing one will have been executed when the error occurs, ie that this is not atomic. This is nothing new with this PR, though. Destructive writes in on-connect/-change-user queries are generally a bad idea, I'd say.

I also corrected a slight inconsistency in the `mysql_change_user_tests` that have actually nothing to do with the issue at hand, but I didn't think it worth a separate PR.