### PR TITLE
Default port 0 for unix socket

### DIFF
--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -76,9 +76,11 @@
 %%       name. For details see the documentation for the first argument of
 %%       gen_server:start_link/4.</dd>
 %%   <dt>`{host, Host}'</dt>
-%%   <dd>Hostname of the MySQL database; default `"localhost"'.</dd>
+%%   <dd>Hostname of the MySQL database. Since OTP version 19, it is also
+%%       possible to specify a local (Unix) Socket by specifying
+%%       `{local, SocketFile}'. Default `"localhost"'.</dd>
 %%   <dt>`{port, Port}'</dt>
-%%   <dd>Port; default 3306 if omitted.</dd>
+%%   <dd>Port; default 3306 for non-local or 0 for local (Unix) sockets.</dd>
 %%   <dt>`{user, User}'</dt>
 %%   <dd>Username.</dd>
 %%   <dt>`{password, Password}'</dt>

--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -61,7 +61,13 @@
 init(Opts) ->
     %% Connect
     Host           = proplists:get_value(host, Opts, ?default_host),
-    Port           = proplists:get_value(port, Opts, ?default_port),
+
+    DefaultPort = case Host of
+        {local, _LocalAddr} -> 0;
+        _NonLocalAddr -> ?default_port
+    end,
+    Port           = proplists:get_value(port, Opts, DefaultPort),
+
     User           = proplists:get_value(user, Opts, ?default_user),
     Password       = proplists:get_value(password, Opts, ?default_password),
     Database       = proplists:get_value(database, Opts, undefined),


### PR DESCRIPTION
In reference to #114, this changes the default port behavior if the host is a unix (`{local, ...}`) socket to use `0` instead of `3306`.

Is this style to your liking? It would be possible to override even a user-specified port in case of a `{local, ...}` host setting, but I don't think we should. Just provide a sensible default.

The test I will do later, I'm not on my usual dev machine now ;) I was thinking of checking OTP version first to see if it is >=19 as you suggested, then connecting via the usual `localhost`, query the database for `@@socket` (as this may be different on different OSes, and I can't think of another easy way to find that out), then use that to attempt a `{local, ...}` connect. Ok with you?