### PR TITLE
Make buffer at least as large as recbuf if it wasn’t specifically defined.

### DIFF
--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -94,8 +94,8 @@ init(Opts) ->
 
     %% If buffer wasn't specifically defined make it at least as
     %% large as recbuf, as suggested by the inet:setopts() docs.
-    BufferIsNotDefined = not proplists:is_defined(buffer, TcpOpts),
-    if BufferIsNotDefined ->
+    BufferIsDefined = proplists:is_defined(buffer, TcpOpts),
+    if not BufferIsDefined ->
         {ok, [{buffer, Buffer}, {recbuf, Recbuf}]} = inet:getopts(Socket0,
                                                                   [buffer, 
                                                                    recbuf]),

--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -96,9 +96,8 @@ init(Opts) ->
     %% large as recbuf, as suggested by the inet:setopts() docs.
     BufferIsDefined = proplists:is_defined(buffer, TcpOpts),
     if not BufferIsDefined ->
-        {ok, [{buffer, Buffer}, {recbuf, Recbuf}]} = inet:getopts(Socket0,
-                                                                  [buffer, 
-                                                                   recbuf]),
+        {ok, [{buffer, Buffer}]} = inet:getopts(Socket0, [buffer]),
+        {ok, [{recbuf, Recbuf}]} = inet:getopts(Socket0, [recbuf]),
         ok = inet:setopts(Socket0,[{buffer, max(Buffer, Recbuf)}])
     end,
 


### PR DESCRIPTION
(Fixes #119)

This roughly follows the `myxql` approach: if the user defined a buffer size, use it, otherwise set it. Another option would be to set the buffer size unconditionally; if the user made the buffer small it would then be adjusted to the suggested size, and if they made it large it would remain unchanged.