### PR TITLE
add `tcp_options` to `start_link/1` spec

### DIFF
--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -135,7 +135,8 @@
                    {queries, [iodata()]} |
                    {query_timeout, timeout()} |
                    {found_rows, boolean()} |
-                   {query_cache_time, non_neg_integer()},
+                   {query_cache_time, non_neg_integer()} |
+                   {tcp_options, [gen_tcp:connect_option()]},
          ServerName :: {local, Name :: atom()} |
                        {global, GlobalName :: term()} |
                        {via, Module :: atom(), ViaName :: term()},


### PR DESCRIPTION
In response to https://github.com/mysql-otp/mysql-otp/issues/119#issuecomment-484740620: you're right, fixed it :)