### PR TITLE
WIP: Move on-connect queries and prepares into mysql_conn

### DIFF
--- a/test/mysql_change_user_tests.erl
+++ b/test/mysql_change_user_tests.erl
@@ -40,7 +40,7 @@ correct_credentials_test() ->
 incorrect_credentials_fail_test() ->
     Pid = connect_db(?user1, ?password1),
     TrapExit = erlang:process_flag(trap_exit, true),
-    ?assertError({1045, <<"28000">>, <<"Access denied", _/binary>>},
+    ?assertMatch({error, {1045, <<"28000">>, <<"Access denied", _/binary>>}},
                  mysql:change_user(Pid, ?user2, ?password1)),
     ExitReason = receive {'EXIT', Pid, Reason} -> Reason after 1000 -> error(timeout) end,
     erlang:process_flag(trap_exit, TrapExit),
@@ -129,9 +129,9 @@ execute_queries_test() ->
 execute_queries_failure_test() ->
     Pid = connect_db(?user1, ?password1),
     erlang:process_flag(trap_exit, true),
-    ?assertError(_Reason, mysql:change_user(Pid, ?user2, ?password2, [{queries, [<<"foo">>]}])),
+    {error, Reason} = mysql:change_user(Pid, ?user2, ?password2, [{queries, [<<"foo">>]}]),
     receive
-        {'EXIT', Pid, normal} -> ok
+        {'EXIT', Pid, Reason} -> ok
     after 1000 ->
         error(no_exit_message)
     end,
@@ -151,9 +151,9 @@ prepare_statements_test() ->
 prepare_statements_failure_test() ->
     Pid = connect_db(?user1, ?password1),
     erlang:process_flag(trap_exit, true),
-    ?assertError(_Reason, mysql:change_user(Pid, ?user2, ?password2, [{prepare, [{foo, <<"foo">>}]}])),
+    {error, Reason} = mysql:change_user(Pid, ?user2, ?password2, [{prepare, [{foo, <<"foo">>}]}]),
     receive
-        {'EXIT', Pid, normal} -> ok
+        {'EXIT', Pid, Reason} -> ok
     after 1000 ->
         error(no_exit_message)
     end,

--- a/test/mysql_tests.erl
+++ b/test/mysql_tests.erl
@@ -208,23 +208,23 @@ unix_socket_test() ->
     
 connect_queries_failure_test() ->
     process_flag(trap_exit, true),
-    ?assertError(_Reason, mysql:start_link([{user, ?user}, {password, ?password},
-                                            {queries, ["foo"]}])),
+    {error, Reason} = mysql:start_link([{user, ?user}, {password, ?password},
+                                        {queries, ["foo"]}]),
     receive
-        {'EXIT', _Pid, normal} -> ok
+        {'EXIT', _Pid, Reason} -> ok
     after 1000 ->
-        error(no_exit_message)
+        exit(no_exit_message)
     end,
     process_flag(trap_exit, false).
 
 connect_prepare_failure_test() ->
     process_flag(trap_exit, true),
-    ?assertError(_Reason, mysql:start_link([{user, ?user}, {password, ?password},
-                                            {prepare, [{foo, "foo"}]}])),
+    {error, Reason} = mysql:start_link([{user, ?user}, {password, ?password},
+                                        {prepare, [{foo, "foo"}]}]),
     receive
-        {'EXIT', _Pid, normal} -> ok
+        {'EXIT', _Pid, Reason} -> ok
     after 1000 ->
-        error(no_exit_message)
+        exit(no_exit_message)
     end,
     process_flag(trap_exit, false).
 


### PR DESCRIPTION
This is an early draft, nothing but the bare necessities to make this work.

The behavior of `start_link` has changed a bit in the case when errors occur in the execution of the on-connect queries and prepares. Before, an exception would be (manually) raised, now an error tuple is returned (via `{stop, ...}` returned from `init`). The behavior of `change_user` has changed likewise, to match that of `start_link`.