### PR TITLE
Treat empty params list as no_params

### DIFF
--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -352,7 +352,8 @@ query(Conn, Query, Params, FilterMap) when (Params == no_params orelse
          Params :: no_params | [term()],
          FilterMap :: no_filtermap_fun | query_filtermap_fun(),
          Result :: query_result().
-query(Conn, Query, no_params, FilterMap, Timeout) ->
+query(Conn, Query, Params, FilterMap, Timeout) when Params =:= no_params; 
+                                                    Params =:= [] ->
     query_call(Conn, {query, Query, FilterMap, Timeout});
 query(Conn, Query, Params, FilterMap, Timeout) ->
     case mysql_protocol:valid_params(Params) of


### PR DESCRIPTION
I passed in empty list params like this:
```
query(Db, Sql) ->                                                                                                                                                                         
    query(Db, Sql, []).                                                                                                                                                                   
                                                                                                                                                                                          
query(Db, Sql, Params) ->                                                                                                                                                                 
    case mysql_poolboy:query(Db, Sql, Params) of                                                                                                                                          
        {error, Reason} ->                                                                                                                                                                
            lager:error("mysql error: ~p, sql: ~s", [Reason, Sql]),                                                                                                                       
            {error, Reason};                                                                                                                                                              
        Result ->                                                                                                                                                                         
            Result                                                                                                                                                                        
    end.
```
and resulted in 
"Can't create more than max_prepared_stmt_count statements"
