### PR TITLE
add:support 'COM_RESET_CONNECTION'

### DIFF
--- a/include/protocol.hrl
+++ b/include/protocol.hrl
@@ -101,6 +101,7 @@
 -define(COM_STMT_RESET, 16#1a).
 -define(COM_SET_OPTION, 16#1b).
 -define(COM_STMT_FETCH, 16#1c).
+-define(COM_RESET_CONNECTION, 16#1f).
 
 %% --- Types ---
 

--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -312,6 +312,11 @@ handle_call({change_user, Username, Password, Options}, From,
             gen_server:reply(From, {error, error_to_reason(E)}),
             stop_server(change_user_failed, State2)
     end;
+handle_call(reset_connection, _From, #state{socket = Socket, sockmod = SockMod} = State) ->
+    setopts(SockMod, Socket, [{active, false}]),
+    Ok = mysql_protocol:reset_connnection(SockMod, Socket),
+    setopts(SockMod, Socket, [{active, once}]),
+    {reply, ok, update_state(Ok, State)};
 handle_call(warning_count, _From, State) ->
     {reply, State#state.warning_count, State};
 handle_call(insert_id, _From, State) ->

--- a/src/mysql_protocol.erl
+++ b/src/mysql_protocol.erl
@@ -31,7 +31,8 @@
          query/4, query/5, fetch_query_response/3,
          fetch_query_response/4, prepare/3, unprepare/3,
          execute/5, execute/6, fetch_execute_response/3,
-         fetch_execute_response/4, valid_params/1]).
+         fetch_execute_response/4, reset_connnection/2,
+	 valid_params/1]).
 
 -type query_filtermap() :: no_filtermap_fun
                          | fun(([term()]) -> query_filtermap_res())
@@ -252,6 +253,12 @@ change_user(SockModule, Socket, Username, Password, Salt, Database,
         ?error_pattern ->
             parse_error_packet(Packet)
     end.
+
+-spec reset_connnection(module(), term()) -> #ok{}.
+reset_connnection(SockModule, Socket) ->
+    {ok, SeqNum1} = send_packet(SockModule, Socket, <<?COM_RESET_CONNECTION>>, 0),
+    {ok, OkPacket, _SeqNum2} = recv_packet(SockModule, Socket, SeqNum1),
+    #ok{status = ?COM_INIT_DB, insert_id = 0} = parse_ok_packet(OkPacket).
 
 %% --- internal ---
 

--- a/test/mysql_tests.erl
+++ b/test/mysql_tests.erl
@@ -173,6 +173,19 @@ keep_alive_test() ->
      ?assertMatch({crash_report, _}, LoggedReport),
      ?assertExit(noproc, mysql:stop(Pid)).
 
+reset_connection_test() ->
+    Options = [{user, ?user}, {password, ?password}, {keep_alive, true}],
+    {ok, Pid} = mysql:start_link(Options),
+    ?assertEqual(ok, mysql:reset_connection(Pid)),
+    State = get_state(Pid),
+    %% see the recode #state{} in 'mysql_conn.erl'
+    Status = element(16 + 1, State),
+    InsertId = element(18 + 1, State),
+    ?assertEqual(16#02, Status),
+    ?assertEqual(16#00, InsertId),
+    mysql:stop(Pid),
+    ok.
+
 unix_socket_test() ->
     try
         list_to_integer(erlang:system_info(otp_release))


### PR DESCRIPTION
A more lightweightt version of COM_CHANGE_USER that does about the same to clean up the session state, but:

1. it does not re-authenticate (and do the extra client/server exchange for that)
2. it does not close the connection

more : https://dev.mysql.com/doc/dev/mysql-server/8.0.11/page_protocol_com_reset_connection.html