### PR TITLE
Remove error log when tcp_closed

### DIFF
--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -414,7 +414,7 @@ handle_info(ping, #state{socket = Socket, sockmod = SockMod} = State) ->
     setopts(SockMod, Socket, [{active, once}]),
     {noreply, update_state(Ok, State)};
 handle_info({tcp_closed, _Socket}, State) ->
-    stop_server(tcp_closed, State);
+    {stop, normal, State#state{socket = undefined, connection_id = undefined}}; 
 handle_info({tcp_error, _Socket, Reason}, State) ->
     stop_server({tcp_error, Reason}, State);
 handle_info(_Info, State) ->
@@ -422,7 +422,7 @@ handle_info(_Info, State) ->
 
 %% @private
 terminate(Reason, #state{socket = Socket, sockmod = SockMod})
-  when Reason == normal; Reason == shutdown ->
+  when Socket =/= undefined andalso (Reason == normal orelse Reason == shutdown) ->
       %% Send the goodbye message for politeness.
       setopts(SockMod, Socket, [{active, false}]),
       mysql_protocol:quit(SockMod, Socket);


### PR DESCRIPTION
I met a lot of tcp_closed error message when mysql wait_timeout expires,
I'd rather treat this kind of connection close as normal, not error.
My wait_timeout is 2 hours , when night comes, some connection will stay idle for longger than 2 hours and get closed.
So I got many error alerts......