### PR TITLE
Fix failing test for change user with incorrect credentials

### DIFF
--- a/test/mysql_change_user_tests.erl
+++ b/test/mysql_change_user_tests.erl
@@ -40,17 +40,18 @@ correct_credentials_test() ->
 incorrect_credentials_fail_test() ->
     Pid = connect_db(?user1, ?password1),
     TrapExit = erlang:process_flag(trap_exit, true),
-    {ok, Ret, Logged} = error_logger_acc:capture(
-        fun () -> mysql:change_user(Pid, ?user2, ?password1) end),
+    {ok, {Ret, ExitReason}, Logged} = error_logger_acc:capture(fun () ->
+        ChangeUserReturn = mysql:change_user(Pid, ?user2, ?password1),
+        receive {'EXIT', Pid, Reason} -> {ChangeUserReturn, Reason}
+        after 1000 -> error(no_exit_message)
+        end
+    end),
+    erlang:process_flag(trap_exit, TrapExit),
     ?assertMatch([{error, "Connection Id " ++ _}, % closing with reason: cha...
                   {error, "** Generic server" ++ _},
                   {error_report, {crash_report, _}}], Logged),
     ?assertMatch({error, {1045, <<"28000">>, <<"Access denied", _/binary>>}},
                  Ret),
-    ExitReason = receive {'EXIT', Pid, Reason} -> Reason
-                 after 1000 -> error(timeout)
-                 end,
-    erlang:process_flag(trap_exit, TrapExit),
     ?assertEqual(change_user_failed, ExitReason),
     ?assertExit(noproc, mysql:stop(Pid)),
     ok.
@@ -136,20 +137,17 @@ execute_queries_test() ->
 execute_queries_failure_test() ->
     Pid = connect_db(?user1, ?password1),
     erlang:process_flag(trap_exit, true),
-    {ok, Ret, Logged} = error_logger_acc:capture(
-        fun () ->
-            mysql:change_user(Pid, ?user2, ?password2, [{queries, [<<"foo">>]}])
-        end),
+    {ok, Ret, Logged} = error_logger_acc:capture(fun () ->
+        Ret1 = mysql:change_user(Pid, ?user2, ?password2, [{queries, [<<"foo">>]}]),
+        receive {'EXIT', Pid, _Reason} -> Ret1
+        after 1000 -> error(no_exit_message)
+        end
+    end),
     ?assertMatch([{error, "Connection Id " ++ _}, % closing with reason: {1064,
                   {error, "** Generic server" ++ _},
                   {error_report, {crash_report, _}}], Logged),
     {error, Reason} = Ret,
     ?assertMatch({1064, <<"42000">>, <<"You have an erro", _/binary>>}, Reason),
-    receive
-        {'EXIT', Pid, Reason} -> ok
-    after 1000 ->
-        error(no_exit_message)
-    end,
     erlang:process_flag(trap_exit, false).
 
 prepare_statements_test() ->
@@ -167,21 +165,18 @@ prepare_statements_test() ->
 prepare_statements_failure_test() ->
     Pid = connect_db(?user1, ?password1),
     erlang:process_flag(trap_exit, true),
-    {ok, Ret, Logged} = error_logger_acc:capture(
-        fun () ->
-            mysql:change_user(Pid, ?user2, ?password2,
-                              [{prepare, [{foo, <<"foo">>}]}])
-        end),
+    {ok, Ret, Logged} = error_logger_acc:capture(fun () ->
+        Ret1 = mysql:change_user(Pid, ?user2, ?password2,
+                                 [{prepare, [{foo, <<"foo">>}]}]),
+       receive {'EXIT', Pid, _Reason} -> Ret1
+       after 1000 -> error(no_exit_message)
+       end
+    end),
     ?assertMatch([{error, "Connection Id " ++ _}, % closing with reason: {1064,
                   {error, "** Generic server" ++ _},
                   {error_report, {crash_report, _}}], Logged),
     {error, Reason} = Ret,
     ?assertMatch({1064, <<"42000">>, <<"You have an erro", _/binary>>}, Reason),
-    receive
-        {'EXIT', Pid, Reason} -> ok
-    after 1000 ->
-        error(no_exit_message)
-    end,
     erlang:process_flag(trap_exit, false).
 
 


### PR DESCRIPTION
The test `mysql_change_user_tests:incorrect_credentials_fail_test` had intermittend failures due to a race condition.