### PR TITLE
Travis tests for MySQL 5.6 - 8.0 and MariaDB 10.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
-dist: xenial
-sudo: true
+os: linux
 language: erlang
-services:
-  - mysql
-env:
-  - MYSQL8=0
-  - MYSQL8=1
 before_script:
   - if [ $MYSQL8 = 1 ]; then
       wget https://repo.mysql.com/mysql-apt-config_0.8.14-1_all.deb;
@@ -23,20 +17,58 @@ before_script:
   - cat test/ssl/my-ssl.cnf | sudo tee -a /etc/mysql/conf.d/my-ssl.cnf
   - sudo service mysql start
   - sleep 5
-  - mysql -uroot -e "CREATE USER otptest@localhost IDENTIFIED BY 'otptest';"
-  - mysql -uroot -e "GRANT ALL PRIVILEGES ON otptest.* TO otptest@localhost;"
-  - mysql -uroot -e "CREATE USER otptest2@localhost IDENTIFIED BY 'otptest2';"
-  - mysql -uroot -e "GRANT ALL PRIVILEGES ON otptest.* TO otptest2@localhost;"
-  - mysql -uroot -e "CREATE USER otptestssl@localhost IDENTIFIED BY 'otptestssl' REQUIRE SSL;"
-  - mysql -uroot -e "GRANT ALL PRIVILEGES ON otptest.* TO otptestssl@localhost;"
+  - sudo mysql -uroot -e "CREATE USER otptest@localhost IDENTIFIED BY 'otptest';"
+  - sudo mysql -uroot -e "GRANT ALL PRIVILEGES ON otptest.* TO otptest@localhost;"
+  - sudo mysql -uroot -e "CREATE USER otptest2@localhost IDENTIFIED BY 'otptest2';"
+  - sudo mysql -uroot -e "GRANT ALL PRIVILEGES ON otptest.* TO otptest2@localhost;"
+  # REQUIRE SSL must be specified only in CREATE USER in MySQL >= 8.0, only in GRANT in MySQL < 5.7;
+  # MySQL 5.7 allows both variants.
+  - (sudo mysql -uroot -e "CREATE USER otptestssl@localhost IDENTIFIED BY 'otptestssl' REQUIRE SSL;" &&
+    sudo mysql -uroot -e "GRANT ALL PRIVILEGES ON otptest.* TO otptestssl@localhost;") ||
+    (sudo mysql -uroot -e "CREATE USER otptestssl@localhost IDENTIFIED BY 'otptestssl';" &&
+    sudo mysql -uroot -e "GRANT ALL PRIVILEGES ON otptest.* TO otptestssl@localhost REQUIRE SSL;")
 script: 'make tests'
-otp_release:
-  - 22.0
-  - 21.1
-  - 21.0
-  - 20.0
-  - 19.0
-  - 18.3
-  - 17.3
-  - 17.0
-  - R16B03-1
+jobs:
+  include:
+    - name: OTP/22.1 + MySQL8.0
+      dist: xenial
+      env: MYSQL8=1
+      services:
+        - mysql
+      otp_release: 22.1
+    - name: OTP/21.3 + MySQL5.7
+      dist: xenial
+      env: MYSQL8=0
+      services:
+        - mysql
+      otp_release: 21.3
+    - name: OTP/20.1 + MySQL5.6
+      dist: trusty
+      env: MYSQL8=0
+      services:
+        - mysql
+      otp_release: 20.1
+    - name: OTP/19.3 + MariaDB10.3
+      dist: xenial
+      addons:
+        mariadb: '10.3'
+      env: MYSQL8=0
+      otp_release: 19.3
+    - name: OTP/18.3 + MySQL8.0
+      dist: xenial
+      env: MYSQL8=1
+      services:
+        - mysql
+      otp_release: 18.3
+    - name: OTP/17.3 + MariaDB10.3
+      dist: xenial
+      addons:
+        mariadb: '10.3'
+      env: MYSQL8=0
+      otp_release: 17.3
+    - name: OTP/R16B03-1 + MySQL5.6
+      dist: trusty
+      env: MYSQL8=0
+      services:
+        - mysql
+      otp_release: R16B03-1

--- a/README.md
+++ b/README.md
@@ -124,8 +124,13 @@ GRANT ALL PRIVILEGES ON otptest.* TO otptest@localhost;
 CREATE USER otptest2@localhost IDENTIFIED BY 'otptest2';
 GRANT ALL PRIVILEGES ON otptest.* TO otptest2@localhost;
 
+# in MySQL < 5.7, REQUIRE SSL must be given in GRANT
 CREATE USER otptestssl@localhost IDENTIFIED BY 'otptestssl';
 GRANT ALL PRIVILEGES ON otptest.* TO otptestssl@localhost REQUIRE SSL;
+
+# in MySQL >= 8.0, REQUIRE SSL must be given in CREATE USER
+CREATE USER otptestssl@localhost IDENTIFIED BY 'otptestssl' REQUIRE SSL;
+GRANT ALL PRIVILEGES ON otptest.* TO otptestssl@localhost;
 ```
 
 Before running the test suite `ssl_tests` you'll also need to generate SSL files


### PR DESCRIPTION
#99

This is the best I could come up with. It defines an explicit job for each Ubuntu distro (thus, MySQL version, precise for 5.5, trusty for 5.6, xenial for 5.7, and xenial upgrading from 5.7 to 8.0) and OTP version (excluding >=21.0 in precise, as it seems it is not supported there).

The same can probably be done for MariaDB.

This PR is based on the caching_sha2_password PR, so I can run the tests against MySQL 8.0.