### PR TITLE
Workaround for changed deadlock handling in MySQL 5.7+

### DIFF
--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -677,8 +677,9 @@ handle_query_call_result([Rec|Recs], RecNum, Query,
         #error{code = ?ERROR_DEADLOCK} when L /= [] ->
             %% These errors result in an implicit rollback.
             Reply = {implicit_rollback, length(L), error_to_reason(Rec)},
-            %% Everything in the transaction is rolled back, except the BEGIN
-            %% statement itself. Thus, we are in transaction level 1.
+            %% The transaction is rollbacked, except the BEGIN, so we're still
+            %% in a transaction.  (In 5.7+, also the BEGIN has been rolled back,
+            %% but here we assume the old behaviour.)
             NewMonitors = demonitor_processes(L, length(L) - 1),
             {Reply, State#state{transaction_levels = NewMonitors}};
         #error{} ->


### PR DESCRIPTION
According to the MySQL docs, when a deadlock error occurs, the
transaction is rollbacked but the BEGIN statement is not cancelled.
This is the case up to MySQL 5.6 but in 5.7, the BEGIN statement
needs to be executed again when restarting a transaction. (The
official MySQL documentation has not been updated to reflect this.)