### PR TITLE
Allow activation of experimental socket backend for inet/gen_tcp (OTP/23)

### DIFF
--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -168,6 +168,11 @@ connect_socket(#state{tcp_opts = TcpOpts, host = Host, port = Port} = State) ->
 
     {ok, State#state{socket = Socket}}.
 
+sanitize_tcp_opts([{inet_backend, _} = InetBackend | TcpOpts0]) ->
+    %% This option is be used to turn on the experimental socket backend for
+    %% gen_tcp/inet (OTP/23). If given, it must remain the first option in the
+    %% list.
+    [InetBackend | sanitize_tcp_opts(TcpOpts0)];
 sanitize_tcp_opts(TcpOpts0) ->
     TcpOpts1 = lists:filter(
         fun


### PR DESCRIPTION
OTP/23 comes with an experimental `socket` backend for `inet`/`gen_tcp` (https://www.erlang.org/news/140), which can be activated by passing `{inet_backend, socket}` _as the first option_ in the connect options. This is currently not possible with `mysql-otp` because the `sanitize_tcp_opts` function prepends some own options to that list: https://github.com/mysql-otp/mysql-otp/blob/1a231bf672f08deae0c82420bda8bb214726d572/src/mysql_conn.erl#L171-L187 

The changes in this PR remove the `inet_backend` option from the front of the given options if present, and put it back in place after prepending the other options. This way, users can experiment with the `socket` backend in `mysql-otp`.