### PR TITLE
Default SNI to hostname for SSL connections

### DIFF
--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -147,7 +147,12 @@
 %%       `{recbuf, Size}' and `{sndbuf, Size}' if you send or receive more than
 %%       the default (typically 8K) per query.</dd>
 %%   <dt>`{ssl, Options}'</dt>
-%%   <dd>Additional options for `ssl:connect/3'.</dd>
+%%   <dd>Additional options for `ssl:connect/3'.<br />
+%%       The `verify' option, if not given explicitly, defaults to
+%%       `verify_peer'.<br />
+%%       The `server_name_indication' option, if omitted, defaults to the value
+%%       of the `host' option if it is a hostname string, otherwise no default
+%%       value is set.</dd>
 %% </dl>
 -spec start_link(Options) -> {ok, pid()} | ignore | {error, term()}
     when Options :: [Option],

--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -192,11 +192,11 @@ sanitize_tcp_opts(TcpOpts0) ->
     [binary, {packet, raw}, {active, false} | TcpOpts2].
 
 handshake(#state{socket = Socket0, ssl_opts = SSLOpts,
-        user = User, password = Password, database = Database,
-        cap_found_rows = SetFoundRows} = State0) ->
+          host = Host, user = User, password = Password, database = Database,
+          cap_found_rows = SetFoundRows} = State0) ->
     %% Exchange handshake communication.
-    Result = mysql_protocol:handshake(User, Password, Database, gen_tcp, SSLOpts,
-                                      Socket0, SetFoundRows),
+    Result = mysql_protocol:handshake(Host, User, Password, Database, gen_tcp,
+                                      SSLOpts, Socket0, SetFoundRows),
     case Result of
         {ok, Handshake, SockMod, Socket} ->
             setopts(SockMod, Socket, [{active, once}]),
@@ -741,7 +741,7 @@ kill_query(#state{connection_id = ConnId, host = Host, port = Port,
     {ok, Socket0} = gen_tcp:connect(Host, Port, SockOpts),
 
     %% Exchange handshake communication.
-    Result = mysql_protocol:handshake(User, Password, undefined, gen_tcp,
+    Result = mysql_protocol:handshake(Host, User, Password, undefined, gen_tcp,
                                       SSLOpts, Socket0, SetFoundRows),
     case Result of
         {ok, #handshake{}, SockMod, Socket} ->

--- a/test/mysql_protocol_tests.erl
+++ b/test/mysql_protocol_tests.erl
@@ -116,7 +116,7 @@ bad_protocol_version_test() ->
     Sock = mock_tcp:create([{recv, <<2, 0, 0, 0, 9, 0>>}]),
     SSLOpts = undefined,
     ?assertError(unknown_protocol,
-                 mysql_protocol:handshake("foo", "bar", "db", mock_tcp,
+                 mysql_protocol:handshake("foo", "bar", "baz", "db", mock_tcp,
                                           SSLOpts, Sock, false)),
     mock_tcp:close(Sock).
 
@@ -129,7 +129,7 @@ error_as_initial_packet_test() ->
     Sock = mock_tcp:create([{recv, Packet}]),
     SSLOpts = undefined,
     ?assertMatch(#error{code = 1040, msg = <<"Too many connections">>},
-                 mysql_protocol:handshake("foo", "bar", "db", mock_tcp,
+                 mysql_protocol:handshake("foo", "bar", "baz", "db", mock_tcp,
                                           SSLOpts, Sock, false)),
     mock_tcp:close(Sock).
 


### PR DESCRIPTION
In response to #164.

While `mysql-otp` sets the `verify` option for SSL connections so that it defaults to `verify_peer`, it does not set any default for `server_name_indication`. Since `ssl:connect/3` is used in the variant that upgrades a TCP socket to SSL, according to the documentation, this causes the SNI option to default to the IP address of the peer, which is probably not what is wanted.

This PR sets up a default for `server_name_indication` as well, defaulting it to the `host` parameter that may be given in the options to `mysql:start_link/1`. From an outside perspective, this has the benefit that the SSL connection process of `mysql-otp` behaves more like `ssl:connect/3` in the variant where it _open_ a SSL connection (vs upgrading an already connected TCP socket) and `server_name_indication` defaults to the given host name (instead of the peer IP address).

If the host given in the `mysql:start_link/1` options is itself an IP address (either in tuple or string form) or an atom (like `loopback`), `server_name_indication` defaults to `disable`. This is different from the `ssl:connect/3` behavior (as outlined above). While this is arguably the more intuitive way to go, it differs from what `ssl` does and would need extra documentation. So I'm putting this up for debate: if the host given in `mysql:start_link/1` is an IP address, should `server_name_indication` default to `disable` (and document that), or should no default be set then and `ssl` be allowed to process it the way it usually does (no additional documentation needed then)?