### PR TITLE
Support LOAD DATA LOCAL revised

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
   - sudo chmod -R 660 /etc/mysql/*.pem
   - sudo chown -R mysql:mysql /etc/mysql/*.pem
   - cat test/ssl/my-ssl.cnf | sudo tee -a /etc/mysql/conf.d/my-ssl.cnf
+  - (echo '[mysqld]'; echo 'local_infile=ON') | sudo tee -a /etc/mysql/conf.d/my-otp.cnf
   - sudo service mysql start
   - sleep 5
   - sudo mysql -uroot -e "CREATE USER otptest@localhost IDENTIFIED BY 'otptest';"

--- a/include/protocol.hrl
+++ b/include/protocol.hrl
@@ -21,6 +21,7 @@
 -define(EOF, 16#fe).
 -define(MORE_DATA, 16#01).
 -define(ERROR, 16#ff).
+-define(LOCAL_INFILE_REQUEST, 16#fb).
 
 %% Character sets
 -define(UTF8MB3, 16#21). %% utf8_general_ci
@@ -38,6 +39,10 @@
 %% Server: supports schema-name in Handshake Response Packet
 %% Client: Handshake Response Packet contains a schema-name
 -define(CLIENT_CONNECT_WITH_DB, 16#00000008).
+
+%% Server: Enables the LOCAL INFILE request of LOAD DATA|XML
+%% Client: Will handle LOCAL INFILE request
+-define(CLIENT_LOCAL_FILES, 16#00000080).
 
 %% Server: supports the 4.1 protocol
 %% Client: uses the 4.1 protocol

--- a/include/records.hrl
+++ b/include/records.hrl
@@ -39,8 +39,8 @@
              warning_count :: integer(),
              msg :: binary()}).
 %% Error packet, commonly used in the protocol.
--record(error, {source = server :: server | client, code :: integer(),
-		state :: binary() | undefined, msg :: binary()}).
+-record(error, {code :: integer(), state :: binary() | undefined,
+                msg :: binary()}).
 
 %% EOF packet, commonly used in the protocol.
 -record(eof, {status, warning_count}).

--- a/include/records.hrl
+++ b/include/records.hrl
@@ -39,8 +39,8 @@
              warning_count :: integer(),
              msg :: binary()}).
 %% Error packet, commonly used in the protocol.
--record(error, {code :: integer(), state :: binary() | undefined,
-                msg :: binary()}).
+-record(error, {source = server :: server | client, code :: integer(),
+		state :: binary() | undefined, msg :: binary()}).
 
 %% EOF packet, commonly used in the protocol.
 -record(eof, {status, warning_count}).

--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -82,7 +82,7 @@
                 | {database, iodata()}
                 | {connect_mode, synchronous | asynchronous | lazy}
                 | {connect_timeout, timeout()}
-                | {local_files, disallow | allow}
+                | {allowed_local_paths, [file:name_all()]}
                 | {log_warnings, boolean()}
                 | {log_slow_queries, boolean()}
                 | {keep_alive, boolean() | timeout()}
@@ -143,14 +143,12 @@
 %%   </dd>
 %%   <dt>`{connect_timeout, Timeout}'</dt>
 %%   <dd>The maximum time to spend for start_link/1.</dd>
-%%   <dt>`{local_files, disallow | allow}'</dt>
-%%   <dd>If set to `allow', the client will advertise the `CLIENT_LOCAL_FILES'
-%%       capability in the handshake and send local data on request, for example
-%%       as part of a `LOAD DATA LOCAL INFILE' query. As this is a potential threat
-%%       that would allow hijacked servers to request any file from the client machine
-%%       to which the client has access to, the default is `disallow', so the capability
-%%       is not advertised and any such requests from the server result in an `exit'
-%%       exception with reason `unexpected_local_infile_request'.</dd>
+%%   <dt>`{allowed_local_paths, [file:name_all()]}'</dt>
+%%   <dd>This option allows you to specify a list of directories or individual
+%%       files on the client machine which the server may request, for example
+%%       when executing a `LOAD DATA LOCAL INFILE' query. Only absolute paths
+%%       are allowed. The default is an empty list, meaning the client will
+%%       not send any local files to the server.</dd>
 %%   <dt>`{log_warnings, boolean()}'</dt>
 %%   <dd>Whether to fetch warnings and log them using error_logger; default
 %%       true.</dd>

--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -82,7 +82,7 @@
                 | {database, iodata()}
                 | {connect_mode, synchronous | asynchronous | lazy}
                 | {connect_timeout, timeout()}
-                | {allowed_local_paths, [file:name_all()]}
+                | {allowed_local_paths, [binary()]}
                 | {log_warnings, boolean()}
                 | {log_slow_queries, boolean()}
                 | {keep_alive, boolean() | timeout()}
@@ -143,12 +143,13 @@
 %%   </dd>
 %%   <dt>`{connect_timeout, Timeout}'</dt>
 %%   <dd>The maximum time to spend for start_link/1.</dd>
-%%   <dt>`{allowed_local_paths, [file:name_all()]}'</dt>
+%%   <dt>`{allowed_local_paths, [binary()]}'</dt>
 %%   <dd>This option allows you to specify a list of directories or individual
 %%       files on the client machine which the server may request, for example
 %%       when executing a `LOAD DATA LOCAL INFILE' query. Only absolute paths
-%%       are allowed. The default is an empty list, meaning the client will
-%%       not send any local files to the server.</dd>
+%%       without relative components such as `..' and `.' are allowed.
+%%       The default is an empty list, meaning the client will not send any
+%%       local files to the server.</dd>
 %%   <dt>`{log_warnings, boolean()}'</dt>
 %%   <dd>Whether to fetch warnings and log them using error_logger; default
 %%       true.</dd>

--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -82,6 +82,7 @@
                 | {database, iodata()}
                 | {connect_mode, synchronous | asynchronous | lazy}
                 | {connect_timeout, timeout()}
+                | {local_files, disallow | allow}
                 | {log_warnings, boolean()}
                 | {log_slow_queries, boolean()}
                 | {keep_alive, boolean() | timeout()}
@@ -142,6 +143,14 @@
 %%   </dd>
 %%   <dt>`{connect_timeout, Timeout}'</dt>
 %%   <dd>The maximum time to spend for start_link/1.</dd>
+%%   <dt>`{local_files, disallow | allow}'</dt>
+%%   <dd>If set to `allow', the client will advertise the `CLIENT_LOCAL_FILES'
+%%       capability in the handshake and send local data on request, for example
+%%       as part of a `LOAD DATA LOCAL INFILE' query. As this is a potential threat
+%%       that would allow hijacked servers to request any file from the client machine
+%%       to which the client has access to, the default is `disallow', so the capability
+%%       is not advertised and any such requests from the server result in an `exit'
+%%       exception with reason `unexpected_local_infile_request'.</dd>
 %%   <dt>`{log_warnings, boolean()}'</dt>
 %%   <dd>Whether to fetch warnings and log them using error_logger; default
 %%       true.</dd>

--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -90,13 +90,7 @@ init(Opts) ->
     Queries           = proplists:get_value(queries, Opts, []),
     Prepares          = proplists:get_value(prepare, Opts, []),
 
-    true = lists:all(
-        fun (AllowedLocalPath) ->
-            PathType = filename:pathtype(AllowedLocalPath),
-            PathType =:= absolute orelse PathType =:= volumerelative
-        end,
-        AllowedLocalPaths
-    ),
+    true = lists:all(fun mysql_protocol:valid_path/1, AllowedLocalPaths),
 
     PingTimeout = case KeepAlive of
         true         -> ?default_ping_timeout;

--- a/test/mysql_protocol_tests.erl
+++ b/test/mysql_protocol_tests.erl
@@ -44,7 +44,9 @@ resultset_test() ->
     ExpectedCommunication = [{send, ExpectedReq},
                              {recv, ExpectedResponse}],
     Sock = mock_tcp:create(ExpectedCommunication),
-    {ok, [ResultSet]} = mysql_protocol:query(Query, mock_tcp, Sock, infinity),
+    {ok, [ResultSet]} = mysql_protocol:query(Query, mock_tcp, Sock,
+                                             disallow_local_files,
+                                             no_filtermap_fun, infinity),
     mock_tcp:close(Sock),
     ?assertMatch(#resultset{cols = [#col{name = <<"@@version_comment">>}],
                             rows = [[<<"MySQL Community Server (GPL)">>]]},
@@ -81,8 +83,21 @@ resultset_error_test() ->
         "48 04 23 48 59 30 30 30    4e 6f 20 74 61 62 6c 65    H.#HY000No table"
         "73 20 75 73 65 64                                     s used"),
     Sock = mock_tcp:create([{send, ExpectedReq}, {recv, ExpectedResponse}]),
-    {ok, [Result]} = mysql_protocol:query(Query, mock_tcp, Sock, infinity),
+    {ok, [Result]} = mysql_protocol:query(Query, mock_tcp, Sock,
+                                          disallow_local_files,
+                                          no_filtermap_fun, infinity),
     ?assertMatch(#error{}, Result),
+    mock_tcp:close(Sock),
+    ok.
+
+unexpected_local_infile_request_test() ->
+    Query = <<"SELECT 1">>,
+    ExpectedReq = <<(size(Query)+1):24/little, 0, ?COM_QUERY, Query/binary>>,
+    UnexpectedResponse = <<16#09:24/little, 16#01, 16#fb, "/tmp/foo">>,
+    Sock = mock_tcp:create([{send, ExpectedReq}, {recv, UnexpectedResponse}]),
+    ?assertExit(unexpected_local_infile_request,
+                mysql_protocol:query(Query, mock_tcp, Sock, disallow_local_files,
+                                     no_filtermap_fun, infinity)),
     mock_tcp:close(Sock),
     ok.
 
@@ -117,7 +132,8 @@ bad_protocol_version_test() ->
     SSLOpts = undefined,
     ?assertError(unknown_protocol,
                  mysql_protocol:handshake("foo", "bar", "baz", "db", mock_tcp,
-                                          SSLOpts, Sock, false)),
+                                          SSLOpts, Sock, disallow_local_files,
+                                          false)),
     mock_tcp:close(Sock).
 
 error_as_initial_packet_test() ->
@@ -130,7 +146,8 @@ error_as_initial_packet_test() ->
     SSLOpts = undefined,
     ?assertMatch(#error{code = 1040, msg = <<"Too many connections">>},
                  mysql_protocol:handshake("foo", "bar", "baz", "db", mock_tcp,
-                                          SSLOpts, Sock, false)),
+                                          SSLOpts, Sock, disallow_local_files,
+                                          false)),
     mock_tcp:close(Sock).
 
 %% --- Helper functions for the above tests ---


### PR DESCRIPTION
#38

This PR adds support for LOAD DATA LOCAL, a long-standing issue. The implementation reads and sends the file in chunks, instead of reading it into memory entirely, to avoid memory problems. Sorry @stuart-thackray, I kinda stole your contribution #103 here. But I noticed that it had acquired some dust over time, and I also noticed that it had some issues to it, so I thought it best to start from scratch, with inspiration taken from your PR.

There is, however, a glitch to it, when the requested file could not be found or opened. In that case, an empty packet must be sent to the server, ie there is no distinction on the server side between an empty and a non-existing/unreadable (on the client side) file, so the error goes unnoticed. While the error may be noticed on the client side. we don't have any facility for reporting client errors to the user (yet).

Another problem popped up while I was working on this PR, but I will write a separate issue for this.