### PR TITLE
allow prepare query to have a timeout

### DIFF
--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -316,7 +316,7 @@ handle_call({param_query, Query, Params, FilterMap, Timeout}, _From,
         not_found ->
             %% Prepare
             setopts(SockMod, Socket, [{active, false}]),
-            Rec = mysql_protocol:prepare(Query, SockMod, Socket),
+            Rec = mysql_protocol:prepare(Query, SockMod, Socket, Timeout),
             setopts(SockMod, Socket, [{active, once}]),
             case Rec of
                 #error{} = E ->


### PR DESCRIPTION
It's been a while but this patch was sitting in
one of my private gist. I believe the issue was
during one of the usage of mysql wherein the underlying
assumption was that timeout was applied but eventaully
there were a lot of prepare queries which ended up
in locking the table. Hence the application started
experiencing table lock errors when there were too many
prepare queries and MySQL was unable to cope up with it.
This patch attempts to fix such scenarios and fail with
timeout being applied.