### PR TITLE
fix: use ssl:versions return value as default ssl versions

### DIFF
--- a/src/mysql_protocol.erl
+++ b/src/mysql_protocol.erl
@@ -405,7 +405,8 @@ maybe_do_ssl_upgrade(Host, gen_tcp, Socket0, SeqNum1, Handshake, SSLOpts,
     end.
 
 ssl_connect(Host, Port, ConfigSSLOpts, Timeout) ->
-    DefaultSSLOpts0 = [{versions, [tlsv1]}, {verify, verify_peer}],
+    DefaultSSLOpts0 = [{versions, proplists:get_value(available, ssl:versions())}, 
+		       {verify, verify_peer}],
     DefaultSSLOpts1 = case is_list(Host) andalso inet:parse_address(Host) of
         false -> DefaultSSLOpts0;
         {ok, _} -> DefaultSSLOpts0;


### PR DESCRIPTION
I encountered this error when I try to connect with ssl:

> ssl:connect(Port, [{versions,[tlsv1]},{verify,verify_none},{active,false}], 5000)
{error,{tls_alert,{bad_record_mac,"TLS client: In state hello at tls_record.erl:571 generated CLIENT ALERT: Fatal - Bad Record MAC\n {unsupported_version,{0,0}}"}}}

And the following is a similar PR from hackney:
https://github.com/benoitc/hackney/pull/619/files#diff-828780afc3d340b2952fd6442d1dd478aff3396ee750b236f5fe2a21145824ef