### PR TITLE
Fix and extend server version parsing

### DIFF
--- a/include/records.hrl
+++ b/include/records.hrl
@@ -19,7 +19,8 @@
 %% --- Records ---
 
 %% Returned by parse_handshake/1.
--record(handshake, {server_version :: [integer()],
+-record(handshake, {server_vendor :: mysql | mariadb,
+                    server_version :: [integer()],
                     connection_id :: integer(),
                     capabilities :: integer(),
                     character_set :: integer(),


### PR DESCRIPTION
In MariaDB>=10.0, the real version is prefixed by "5.5.5-". By the changes in this PR, the real version is parsed out. Also, it detects if the server is MySQL or MariaDB.