### PR TITLE
Exit when ssl_options are provided but the server does not support SSL

### DIFF
--- a/src/mysql_protocol.erl
+++ b/src/mysql_protocol.erl
@@ -393,6 +393,10 @@ server_version_to_list(ServerVersion) ->
 maybe_do_ssl_upgrade(_Host, SockModule0, Socket0, SeqNum1, _Handshake,
                      undefined, _Database, _SetFoundRows) ->
     {ok, SockModule0, Socket0, SeqNum1};
+maybe_do_ssl_upgrade(_Host, _SockModule0, _Socket0, _SeqNum1,
+                     #handshake{capabilities=Caps},_SSLOpts, _Database,
+                     _SetFoundRows) when Caps band ?CLIENT_SSL =/= ?CLIENT_SSL ->
+    exit({failed_to_upgrade_socket, ssl_not_supported});
 maybe_do_ssl_upgrade(Host, gen_tcp, Socket0, SeqNum1, Handshake, SSLOpts,
                      Database, SetFoundRows) ->
     Response = build_handshake_response(Handshake, Database, SetFoundRows),


### PR DESCRIPTION
Currently, we try an upgrade to SSL if the user provided `ssl_options`, even if the server does not have the `CLIENT_SSL` flag set in the initial handshake. This is unnecessary and should not be done. There is no security risk here, though, but it results in an obscure tls error message "CLIENT ALERT: Fatal - Bad Record MAC {unsupported_version,{0,0}}". Ie, it tells nothing about the actual reason, namely that the server does not support SSL.

The changes in this PR cause an `exit` with reason `{failed_to_upgrade_socket,ssl_not_supported}` before attempting an SSL upgrade when `ssl_options` were provided but the server does not support SSL. This error reason is more understandable. Alternatively, it would be possible to skip upgrading and continue with plain TCP, but that is not obvious to the user, and he would work under the assumption that the connection was secure since he provided `ssl_options`.

[EDIT]: Yeah, looks like it is a _very_ bad idea to just drop down to plain TCP =^^= https://duo.com/blog/backronym-mysql-vulnerability