### PR TITLE
fix: function clause error in nesting transactions

### DIFF
--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -624,9 +624,10 @@ transaction(Conn, Fun, Retries) ->
 %% can be nested and are restarted automatically when deadlocks are detected.
 %% MySQL's savepoints are used to implement nested transactions.
 %%
-%% If this function is called on a connection which is already in transaction,
-%% `{aborted, busy}` will be returned. Since the idea of "nested transaction" is
-%% that this function can be called in the Fun, but all within the same process.
+%% If this function is called on a connection which is already in a transaction
+%% owned by another process, `{aborted, busy}` is returned. The idea of nested
+%% transactions is that this function can be called in the Fun, but all within
+%% the same process.
 %%
 %% Fun must be a function and Args must be a list of the same length as the
 %% arity of Fun.


### PR DESCRIPTION
We encountered following error:
```
Uncaught exit - {{:function_clause, [{:mysql_conn, :handle_call, [:commit, {#PID<0.18851.2939>, #Reference<0.517344270.338165767.72012>}, {:state, [8, 0, 13], 2757790, #Port<0.23126779>, :gen_tcp, [], :undefined, 'example.com', 3306, "meiqia_ticket", "yourpassword", "tickets", [], [], "mysql_native_password", <<123, 8, 94, 45, 28, 42, 28, 94, 125, 65, 123, 23, 108, 101, 116, 48, 125, 60, 109, 67, 0>>, [], true, false, 5000, :infinity, :infinity, 60000, 0, 3, 0, 0, [{#PID<0.23837.2554>, #Reference<0.517344270.1424752644.79848>}, {#PID<0.18851.2939>, #Reference<0.517344270.338165767.71948>}], :undefined, {:dict, 0, 16, 16, 8, 80, 48, {[], [], ...}, {{...}}}, {:cache, {1642, 754754, 337352}, {:dict, 3, 16, 16, 8, 80, ...}}, false, false}], [file: 'src/mysql_conn.erl', line: 294]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 715]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 744]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 226]}]}, {:gen_server, :call, [#PID<0.2428.0>, :commit, :infinity]}}
```
This happens when transaction a and then transaction b are started sequentially on a connection,
and transaction a commits/rollbacks before transaction b.

This could be reproduced by following snippet
```
{:ok, pid} = :mysql.start_link([{:host,'127.0.0.1'},{:user,<<"test">>},{:password,<<>>},{:database,<<"test">>}])
f1 = fn ->
  Process.sleep(500)
  :mysql.query(pid, "show databases;")
end

f2 = fn ->
  Process.sleep(1000)
  :mysql.query(pid, "show databases;")
end
spawn(fn -> {:atomic, _} = :mysql.transaction(pid, f2) end); {:atomic, _} = :mysql.transaction(pid, f1)
```