### PR TITLE
Obfuscate password and critical SSL options

### DIFF
--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -28,7 +28,7 @@
 
 -behaviour(gen_server).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
-         code_change/3]).
+         code_change/3, format_status/2]).
 
 -define(default_host, "localhost").
 -define(default_port, 3306).
@@ -830,3 +830,19 @@ demonitor_processes(List, 0) ->
 demonitor_processes([{_FromPid, MRef}|T], Count) ->
     erlang:demonitor(MRef),
     demonitor_processes(T, Count - 1).
+
+format_status(normal, [_PDict, State]) ->
+	{data, [{"State", State}]};
+format_status(terminate, [_PDict, State=#state{ssl_opts=undefined}]) ->
+	{data, [{"State", State#state{password = hidden}}]};
+format_status(terminate, [_PDict, State=#state{ssl_opts=SSLOpts}]) ->
+	SSLOpts1 = lists:map(
+		fun
+			({cert, _}) -> {cert, hidden};
+			({key, _}) -> {key, hidden};
+			({cacerts, _}) -> {cacerts, hidden};
+			(Other) -> Other
+		end,
+		SSLOpts
+        ),
+	{data, [{"State", State#state{password = hidden, ssl_opts=SSLOpts1}}]}.


### PR DESCRIPTION
When a `mysql_conn` process crashes, sensitive information can end up in logs.

This implementation of `format_status` replaces the value of `password` in the state record with the atom `hidden`, and likewise replaces the values for keys `key`, `cert` and `cacerts` with `hidden` in the SSL options.

The obfuscation only takes place if the process terminates (abnormally) which is where logging typically appears, ie the values are not touched when `sys:get_status` is used. The "real" state can be retrieved when `sys:get_state` is used, anyway.