### PR TITLE
Allow binary as the name of prepared statement

### DIFF
--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -63,7 +63,7 @@
                              | {true, term()}.
 
 -type statement_id() :: integer().
--type statement_name() :: atom().
+-type statement_name() :: atom() | binary().
 -type statement_ref() :: statement_id() | statement_name().
 
 -type decode_decimal() :: auto | binary | float | number.

--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -385,10 +385,13 @@ handle_call({prepare, Query}, _From, State) ->
             State2 = State#state{stmts = Stmts1},
             {reply, {ok, Id}, State2}
     end;
-handle_call({prepare, Name, Query}, _From, State) ->
+handle_call({prepare, Name, Query}, _From, State) when is_atom(Name);
+                                                       is_binary(Name) ->
     {Reply, State1} = named_prepare(Name, Query, State),
     {reply, Reply, State1};
-handle_call({unprepare, Stmt}, _From, State) ->
+handle_call({unprepare, Stmt}, _From, State) when is_atom(Stmt);
+                                                  is_integer(Stmt);
+                                                  is_binary(Stmt) ->
     case dict:find(Stmt, State#state.stmts) of
         {ok, StmtRec} ->
             #state{socket = Socket, sockmod = SockMod} = State,

--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -385,11 +385,10 @@ handle_call({prepare, Query}, _From, State) ->
             State2 = State#state{stmts = Stmts1},
             {reply, {ok, Id}, State2}
     end;
-handle_call({prepare, Name, Query}, _From, State) when is_atom(Name) ->
+handle_call({prepare, Name, Query}, _From, State) ->
     {Reply, State1} = named_prepare(Name, Query, State),
     {reply, Reply, State1};
-handle_call({unprepare, Stmt}, _From, State) when is_atom(Stmt);
-                                                  is_integer(Stmt) ->
+handle_call({unprepare, Stmt}, _From, State) ->
     case dict:find(Stmt, State#state.stmts) of
         {ok, StmtRec} ->
             #state{socket = Socket, sockmod = SockMod} = State,


### PR DESCRIPTION
This is to avoid creating atoms when making use of prepared statements.