### PR TITLE
Remove exception handling macros

### DIFF
--- a/include/exception.hrl
+++ b/include/exception.hrl
@@ -1,7 +1,0 @@
--ifdef(OTP_RELEASE). %% this implies 21 or higher
--define(EXCEPTION(Class, Reason, Stacktrace), Class:Reason:Stacktrace).
--define(GET_STACK(Stacktrace), Stacktrace).
--else.
--define(EXCEPTION(Class, Reason, _), Class:Reason).
--define(GET_STACK(_), erlang:get_stacktrace()).
--endif.

--- a/test/error_logger_acc.erl
+++ b/test/error_logger_acc.erl
@@ -13,8 +13,6 @@
 %% TODO: Use logger by default and use error_logger only for old OTP releases.
 -module(error_logger_acc).
 
--include("exception.hrl").
-
 %% Public API
 -export([capture/1]).
 
@@ -47,11 +45,11 @@ capture(Fun) when is_function(Fun, 0) ->
             restore_default_logger_handler(DefaultLoggerHandler),
             {ok, Result, error_logger:delete_report_handler(?MODULE)}
     catch
-        ?EXCEPTION(Class, Error, Stacktrace) ->
+        Class:Error:Stacktrace ->
             lists:foreach(fun error_logger:add_report_handler/1, OldHandlers),
             AccumulatedErrors = error_logger:delete_report_handler(?MODULE),
             restore_default_logger_handler(DefaultLoggerHandler),
-            {Class, Error, ?GET_STACK(Stacktrace), AccumulatedErrors}
+            {Class, Error, Stacktrace, AccumulatedErrors}
     end.
 
 %% --- gen_event callbacks ---


### PR DESCRIPTION
Since we are now targeting OTP>=22, we can also remove the exception handling switch macros, as `Class:Reason:Stacktrace` is supported since OTP 21.