### PR TITLE
Call SockMod:close before stop

### DIFF
--- a/test/ssl_tests.erl
+++ b/test/ssl_tests.erl
@@ -65,6 +65,8 @@ owner_down_test() ->
     receive
         {'DOWN', Mref, _, Pid, Reason} ->
             ?assertEqual({application_process_died, Caller}, Reason)
+    after 1000 ->
+        error(down_signal_not_received)
     end.
 
 start_apps() ->


### PR DESCRIPTION
When a transaction caller process exits, `mysql_conn` will close the socket and stop itself.
Prior to this fix, the socket close function call disregards the transport implementation module (`sockmod`), always calls `gen_tcp:close` and matches it against `ok`. This PR changes to `ok = SockMod:close(...),`.

Additionally, the `flush` option is added to the `demonitor` call, when a transaction monitor is demonitored.

----

I'd like to discuss though if it really makes sense to stop with a reason other than `shutdown` or `normal`,
because this will cause a crash log emitted regardless of the reason of owner processes' exit reason. 

Below is a crash log example:

```
.=ERROR REPORT==== 20-Nov-2024::14:18:33.240184 ===
Connection Id 15 closing with reason: {application_process_died,<0.453.0>}

=ERROR REPORT==== 20-Nov-2024::14:18:33.240526 ===
** Generic server tardis terminating
** Last message in was {'DOWN',#Ref<0.1068720556.291766273.97155>,process,
                               <0.453.0>,normal}
** When Server state == {state,
                            [8,4,2],
                            undefined,undefined,ssl,[],
                            [{server_name_indication,disable},
                             {cacertfile,"test/ssl/ca.pem"}],
                            "localhost",3306,"otptestssl",hidden,undefined,
                            ["SET @foo = 'bar'","SELECT 1",
                             "SELECT 1; SELECT 2"],
                            [{foo,"SELECT @foo"}],
                            <<"caching_sha2_password">>,
                            <<125,108,113,76,78,114,60,14,112,9,20,96,120,33,
                              122,106,63,94,124,8,0>>,
                            [],true,false,5000,infinity,infinity,60000,0,3,0,
                            0,
                            [{<0.453.0>,#Ref<0.1068720556.291766273.97155>}],
                            undefined,
                            {dict,1,16,16,8,80,48,
                                {[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],
                                 []},
                                {{[],[],[],[],[],[],[],[],[],[],[],[],[],[],
                                  [],
                                  [[foo|{prepared,1,"SELECT @foo",0,0}]]}}},
                            empty,false,false,auto}
** Reason for termination ==
** {application_process_died,<0.453.0>}
```