### PR TITLE
Fix failing edoc

### DIFF
--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -488,7 +488,7 @@ execute(Conn, StatementRef, Params, FilterMap) when FilterMap == no_filtermap_fu
 %% See `query/5' for an explanation of the `FilterMap' argument.
 %%
 %% Note that if this function is called on a connection which is already in transaction 
-%% owned by another process, `{error, busy}` will be returned.
+%% owned by another process, `{error, busy}' will be returned.
 %%
 %% @see prepare/2
 %% @see prepare/3

--- a/src/mysql_protocol.erl
+++ b/src/mysql_protocol.erl
@@ -444,7 +444,7 @@ ssl_connect(Handshake, Host, Port, ConfigSSLOpts, Timeout) ->
 
 
 %% @doc Determines which ssl versions to use according to server vendor and version
-%% since almostly, mysql < 5.7.0 and mariadb < 10.1.0 supports only tlsv1
+%% since almostly, mysql &lt; 5.7.0 and mariadb &lt; 10.1.0 supports only tlsv1
 -spec determine_ssl_versions(#handshake{}) -> list().
 determine_ssl_versions(#handshake{server_vendor = mysql, server_version = Version}) when Version < [5, 7, 0] ->
     [tlsv1];


### PR DESCRIPTION
`make docs` was failing because of these edoc syntax errors.